### PR TITLE
Fast Confirmation: Update current_epoch_observed_justified_checkpoint at an epoch start

### DIFF
--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -122,6 +122,7 @@ class Store(object):
     confirmed_root: Root
     previous_epoch_observed_justified_checkpoint: Checkpoint
     current_epoch_observed_justified_checkpoint: Checkpoint
+    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
     previous_slot_head: Root
     current_slot_head: Root
     equivocating_indices: Set[ValidatorIndex]
@@ -156,6 +157,7 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         confirmed_root=anchor_root,
         previous_epoch_observed_justified_checkpoint=justified_checkpoint,
         current_epoch_observed_justified_checkpoint=justified_checkpoint,
+        previous_epoch_greatest_unrealized_checkpoint=justified_checkpoint,
         previous_slot_head=anchor_root,
         current_slot_head=anchor_root,
         equivocating_indices=set(),

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -134,6 +134,7 @@ class Store(object):
     confirmed_root: Root
     previous_epoch_observed_justified_checkpoint: Checkpoint
     current_epoch_observed_justified_checkpoint: Checkpoint
+    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
     previous_slot_head: Root
     current_slot_head: Root
     equivocating_indices: Set[ValidatorIndex]
@@ -172,6 +173,7 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         confirmed_root=anchor_root,
         previous_epoch_observed_justified_checkpoint=justified_checkpoint,
         current_epoch_observed_justified_checkpoint=justified_checkpoint,
+        previous_epoch_greatest_unrealized_checkpoint=justified_checkpoint,
         previous_slot_head=anchor_root,
         current_slot_head=anchor_root,
         equivocating_indices=set(),

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -704,12 +704,18 @@ def update_fast_confirmation_variables(store: Store) -> None:
     store.previous_slot_head = store.current_slot_head
     store.current_slot_head = get_head(store)
 
-    # Update observed justified checkpoint at the beginning of the last slot of an epoch.
+    # Update greatest unrealized justified checkpoint at the last slot of an epoch.
     if is_start_slot_at_epoch(Slot(get_current_slot(store) + 1)):
+        store.previous_epoch_greatest_unrealized_checkpoint = store.unrealized_justified_checkpoint
+
+    # Update observed justified checkpoints at the start of an epoch.
+    if is_start_slot_at_epoch(get_current_slot(store)):
         store.previous_epoch_observed_justified_checkpoint = (
             store.current_epoch_observed_justified_checkpoint
         )
-        store.current_epoch_observed_justified_checkpoint = store.unrealized_justified_checkpoint
+        store.current_epoch_observed_justified_checkpoint = (
+            store.previous_epoch_greatest_unrealized_checkpoint
+        )
 ```
 
 #### `find_latest_confirmed_descendant`

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -173,6 +173,9 @@ The following fields are used by the Fast Confirmation Rule:
 - `current_epoch_observed_justified_checkpoint`: a justified checkpoint that has
   been observed by all honest nodes at the beginning of the current epoch
   assuming synchrony.
+- `previous_epoch_greatest_unrealized_checkpoint`: a greatest unrealized
+  justified checkpoint at the start of the last slot of the previous epoch
+  according to a local view.
 - `previous_slot_head`: the head at the start of the previous slot.
 - `current_slot_head`: the head at the start of the current slot.
 
@@ -189,6 +192,7 @@ class Store(object):
     confirmed_root: Root
     previous_epoch_observed_justified_checkpoint: Checkpoint
     current_epoch_observed_justified_checkpoint: Checkpoint
+    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
     previous_slot_head: Root
     current_slot_head: Root
     equivocating_indices: Set[ValidatorIndex]
@@ -230,6 +234,7 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         confirmed_root=anchor_root,
         previous_epoch_observed_justified_checkpoint=justified_checkpoint,
         current_epoch_observed_justified_checkpoint=justified_checkpoint,
+        previous_epoch_greatest_unrealized_checkpoint=justified_checkpoint,
         previous_slot_head=anchor_root,
         current_slot_head=anchor_root,
         equivocating_indices=set(),

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_empty_slots.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_empty_slots.py
@@ -155,7 +155,6 @@ def test_fcr_handles_multiple_consecutive_empty_slots(spec, state):
 
     yield from fcr.get_test_artefacts()
 
-
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
 @with_custom_state(
@@ -168,15 +167,17 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
     """
     Test that FCR correctly handles an empty slot at the epoch boundary.
 
-    The last slot of an epoch is when GU sampling happens. If this slot is empty,
-    the sampling should still occur correctly.
+    The last slot of an epoch is when the GU snapshot is taken. If this slot
+    is empty, the snapshot should still occur correctly. The rotation of
+    observed checkpoints happens at the first slot of the next epoch.
 
     1. Build chain through most of epoch 0
     2. Make the last slot of epoch 0 empty (slot 7)
     3. Cross into epoch 1 with blocks
     4. Verify:
-       - GU sampling occurred correctly at the empty last slot
-       - Epoch boundary logic works correctly
+       - GU snapshot taken correctly at the empty last slot
+       - Observed checkpoints do NOT rotate at the last slot
+       - Observed checkpoints DO rotate at epoch 1 start
        - No spurious resets
     """
     fcr = FCRTest(spec, seed=1)
@@ -195,6 +196,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
     head_before_empty = fcr.head()
     confirmed_before_empty = store.confirmed_root
     current_observed_before = store.current_epoch_observed_justified_checkpoint
+    previous_observed_before = store.previous_epoch_observed_justified_checkpoint
 
     # With 100% participation, head should be confirmed
     assert confirmed_before_empty == head_before_empty
@@ -208,18 +210,33 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     assert fcr.current_slot() == last_slot_epoch0  # slot 7
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1)), (
-        "Should be last slot of epoch (GU sampling slot)"
+        "Should be last slot of epoch (GU snapshot slot)"
     )
 
-    # Run FCR at slot 7 (empty slot) - this triggers GU sampling
+    # Run FCR at slot 7 (empty slot) - this triggers GU snapshot
     fcr.run_fast_confirmation()
 
-    # GU sampling should have happened
-    assert store.previous_epoch_observed_justified_checkpoint == current_observed_before
+    # GU snapshot should have been taken
+    assert (
+        store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
+    ), "GU snapshot should be taken at last slot of epoch even during empty slot"
+
+    # Observed checkpoints should NOT have rotated (PR #25 fix)
+    assert store.current_epoch_observed_justified_checkpoint == current_observed_before, (
+        "current_epoch_observed should NOT change at last slot of epoch"
+    )
+    assert store.previous_epoch_observed_justified_checkpoint == previous_observed_before, (
+        "previous_epoch_observed should NOT change at last slot of epoch"
+    )
 
     # Head unchanged (empty slot), confirmed stays the same
     assert fcr.head() == head_before_empty
     assert store.confirmed_root == head_before_empty
+
+    # Record values before crossing into epoch 1
+    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
+    curr_observed_before_rotation = store.current_epoch_observed_justified_checkpoint
 
     # Attest at slot 7, then cross into epoch 1 (slot 8) WITH A BLOCK
     fcr.attest_and_next_slot_with_fast_confirmation(
@@ -228,6 +245,14 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     assert fcr.current_slot() == epoch1_start  # slot 8
     assert spec.is_start_slot_at_epoch(fcr.current_slot())
+
+    # Rotation should have happened at epoch start
+    assert store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation, (
+        "previous_observed should now equal old current_observed after rotation at epoch start"
+    )
+    assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+        "current_observed should now equal GU snapshot after rotation at epoch start"
+    )
 
     # Propose block at epoch 1 start
     first_block_epoch1 = fcr.add_and_apply_block(
@@ -270,7 +295,6 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     yield from fcr.get_test_artefacts()
 
-
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
 @with_custom_state(
@@ -284,18 +308,19 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     Test that FCR correctly handles empty slots on both sides of an epoch boundary.
 
     Both the last slot of epoch 0 AND the first slot of epoch 1 are empty.
-    This tests:
-    - GU sampling at empty last slot of epoch
-    - Epoch-start logic at empty first slot of new epoch
+    This tests the two-step mechanism:
+    - GU snapshot at empty last slot of epoch (no rotation)
+    - Rotation at empty first slot of new epoch
     - Interaction between these two critical moments
 
     1. Build chain through epoch 0 until slot 5
-    2. Slot 6, 7 (last of epoch 0): EMPTY - GU sampling happens at slot 7
-    3. Slot 8 (first of epoch 1): EMPTY - epoch-start logic runs here
+    2. Slot 6, 7 (last of epoch 0): EMPTY - GU snapshot taken at slot 7
+    3. Slot 8 (first of epoch 1): EMPTY - rotation happens here
     4. Slot 9: first block of epoch 1
     5. Verify:
-       - GU sampling occurred correctly at slot 7
-       - Epoch boundary logic works correctly at slot 8
+       - GU snapshot taken correctly at slot 7
+       - Observed checkpoints NOT rotated at slot 7
+       - Observed checkpoints rotated at slot 8
        - No spurious resets
        - Confirmations continue after resuming blocks
     """
@@ -307,8 +332,6 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     epoch1_start = S  # slot 8
 
     # Build until we're at slot 6
-    # next_slot_with_block_and_fast_confirmation places block then advances
-    # So after the loop, current_slot == 6 and last block was at slot 5
     while fcr.current_slot() < last_slot_epoch0 - 1:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
     assert fcr.current_slot() == last_slot_epoch0 - 1  # slot 6
@@ -318,6 +341,7 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     assert head_slot == 5, f"Last block should be at slot 5, got {head_slot}"
 
     current_observed_before = store.current_epoch_observed_justified_checkpoint
+    previous_observed_before = store.previous_epoch_observed_justified_checkpoint
 
     # Slot 6: EMPTY
     fcr.attest_and_next_slot_with_fast_confirmation(
@@ -325,24 +349,36 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     )
     assert fcr.current_slot() == last_slot_epoch0  # slot 7
 
-    # Slot 7: Last slot of epoch 0 (EMPTY) - GU sampling happens here
+    # Slot 7: Last slot of epoch 0 (EMPTY) - GU snapshot happens here
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1)), (
         "Slot 7 should be last slot of epoch 0"
     )
 
-    # Verify GU sampling happened
-    assert store.previous_epoch_observed_justified_checkpoint == current_observed_before, (
-        "GU sampling should have shifted previous := current"
+    # GU snapshot should have been taken
+    assert (
+        store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
+    ), "GU snapshot should be taken at last slot of epoch"
+
+    # Observed checkpoints should NOT have rotated (PR #25)
+    assert store.current_epoch_observed_justified_checkpoint == current_observed_before, (
+        "current_epoch_observed should NOT change at last slot of epoch"
+    )
+    assert store.previous_epoch_observed_justified_checkpoint == previous_observed_before, (
+        "previous_epoch_observed should NOT change at last slot of epoch"
     )
 
-    current_observed_after_sampling = store.current_epoch_observed_justified_checkpoint
     assert fcr.head() == head_before_empty
+
+    # Record values before crossing into epoch 1
+    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
+    curr_observed_before_rotation = store.current_epoch_observed_justified_checkpoint
 
     slot7_atts = fcr.attest(
         block_root=head_before_empty, slot=fcr.current_slot(), participation_rate=100
     )
 
-    # Slot 8: First slot of epoch 1 (EMPTY)
+    # Slot 8: First slot of epoch 1 (EMPTY) - rotation happens here
     fcr.next_slot()
     fcr.apply_attestations(slot7_atts)
 
@@ -352,8 +388,13 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     fcr.run_fast_confirmation()
 
     assert fcr.head() == head_before_empty
-    assert store.current_epoch_observed_justified_checkpoint == current_observed_after_sampling, (
-        "GU should not change at epoch start (only at epoch end)"
+
+    # Rotation should have happened at epoch start
+    assert store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation, (
+        "previous_observed should now equal old current_observed after rotation at epoch start"
+    )
+    assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+        "current_observed should now equal GU snapshot after rotation at epoch start"
     )
 
     # Slot 8: Attest and move to Slot 9

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_empty_slots.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_empty_slots.py
@@ -155,6 +155,7 @@ def test_fcr_handles_multiple_consecutive_empty_slots(spec, state):
 
     yield from fcr.get_test_artefacts()
 
+
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
 @with_custom_state(
@@ -218,8 +219,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     # GU snapshot should have been taken
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint
-        == store.unrealized_justified_checkpoint
+        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
     ), "GU snapshot should be taken at last slot of epoch even during empty slot"
 
     # Observed checkpoints should NOT have rotated (PR #25 fix)
@@ -295,6 +295,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     yield from fcr.get_test_artefacts()
 
+
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
 @with_custom_state(
@@ -356,8 +357,7 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
 
     # GU snapshot should have been taken
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint
-        == store.unrealized_justified_checkpoint
+        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
     ), "GU snapshot should be taken at last slot of epoch"
 
     # Observed checkpoints should NOT have rotated (PR #25)

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_is_one_confirmed.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_is_one_confirmed.py
@@ -1,0 +1,874 @@
+from eth2spec.test.context import (
+    default_activation_threshold,
+    default_balances,
+    MINIMAL,
+    single_phase,
+    spec_test,
+    with_altair_and_later,
+    with_custom_state,
+    with_presets,
+)
+from eth2spec.test.helpers.fast_confirmation import (
+    FCRTest,
+)
+
+"""
+Test is_one_confirmed
+"""
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_passes_with_full_participation(spec, state):
+    """
+    Test that is_one_confirmed returns True for a block with 100% participation.
+
+    1. Build chain through epoch 1 with 100% participation to establish balance source
+    2. Propose block B with 100% attestations, advance, apply, run FCR
+    3. Call is_one_confirmed directly on B and verify it returns True
+    4. Inspect the individual terms of the inequality
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    # Propose block B with 100% attestations — helper handles the full flow
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Verify no empty slot gap (consecutive slots)
+    block = store.blocks[block_b]
+    parent_block = store.blocks[block.parent_root]
+    assert parent_block.slot + 1 == block.slot, "Test requires consecutive slots"
+
+    # Get balance source
+    balance_source = spec.get_current_balance_source(store)
+
+    # Call is_one_confirmed directly
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "is_one_confirmed should return True with 100% participation"
+    )
+
+    # Inspect the individual terms of the inequality
+    current_slot = spec.get_current_slot(store)
+    support = spec.get_attestation_score(store, block_b, balance_source)
+    proposer_score = spec.compute_proposer_score(balance_source)
+    total_active_balance = spec.get_total_active_balance(balance_source)
+    maximum_support = spec.estimate_committee_weight_between_slots(
+        total_active_balance, spec.Slot(parent_block.slot + 1), spec.Slot(current_slot - 1)
+    )
+    support_discount = spec.get_support_discount(store, balance_source, block_b)
+    adversarial_weight = spec.get_adversarial_weight(store, balance_source, block_b)
+
+    # No empty slots → discount must be 0
+    assert support_discount == 0, f"Expected 0 discount, got {support_discount}"
+
+    # Verify the integer inequality directly
+    lhs = 2 * support + support_discount
+    rhs = maximum_support + proposer_score + 2 * adversarial_weight
+    assert lhs > rhs, (
+        f"Inequality failed: lhs={lhs} vs rhs={rhs}"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_fails_with_low_participation(spec, state):
+    """
+    Test that is_one_confirmed returns False when participation is too low.
+
+    With β = 25%, the threshold is roughly 75-80% of committee weight.
+    At 50% participation, the observed support is insufficient to rule out
+    a competing sibling overtaking the branch.
+
+    1. Build chain through epoch 1 with 100% participation to establish balance source
+    2. Propose block B with only 50% attestations, advance, apply, run FCR
+    3. Call is_one_confirmed directly on B and verify it returns False
+    4. Inspect the terms to verify support is insufficient
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    # Propose block B with only 50% attestations
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=50)
+
+    # Verify no empty slot gap
+    block = store.blocks[block_b]
+    parent_block = store.blocks[block.parent_root]
+    assert parent_block.slot + 1 == block.slot, "Test requires consecutive slots"
+
+    # Get balance source
+    balance_source = spec.get_current_balance_source(store)
+
+    # Call is_one_confirmed directly
+    assert not spec.is_one_confirmed(store, balance_source, block_b), (
+        "is_one_confirmed should return False with only 50% participation"
+    )
+
+    # Inspect the individual terms
+    current_slot = spec.get_current_slot(store)
+    support = spec.get_attestation_score(store, block_b, balance_source)
+    proposer_score = spec.compute_proposer_score(balance_source)
+    total_active_balance = spec.get_total_active_balance(balance_source)
+    maximum_support = spec.estimate_committee_weight_between_slots(
+        total_active_balance, spec.Slot(parent_block.slot + 1), spec.Slot(current_slot - 1)
+    )
+    support_discount = spec.get_support_discount(store, balance_source, block_b)
+    adversarial_weight = spec.get_adversarial_weight(store, balance_source, block_b)
+
+    # Verify the inequality does NOT hold
+    lhs = 2 * support + support_discount
+    rhs = maximum_support + proposer_score + 2 * adversarial_weight
+    assert lhs <= rhs, (
+        f"Inequality unexpectedly holds: lhs={lhs} > rhs={rhs} at 50% participation"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_slashing_supporters_does_not_hurt(spec, state):
+    """
+    Test that slashing validators who voted for block B does not break is_one_confirmed.
+
+    Equivocators are proven Byzantine. Once identified:
+    - Their votes are excluded from B's support
+    - Their weight is subtracted from the adversarial budget
+
+    For validators whose latest message points to B, the support loss and
+    adversarial budget reduction largely cancel out. With sufficient initial
+    margin (100% participation), slashing a moderate fraction does not flip
+    is_one_confirmed from True to False.
+
+    1. Build block B with 100% participation (is_one_confirmed = True)
+    2. Slash 20% of validators randomly (at 100% participation, all are supporters)
+    3. Verify is_one_confirmed remains True
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    # Block B with 100% participation
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    balance_source = spec.get_current_balance_source(store)
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "Precondition: is_one_confirmed should be True at 100%"
+    )
+
+    # Slash 20% randomly — at 100% participation, these are all supporters of B
+    fcr.apply_attester_slashing(slashing_percentage=20, slot=fcr.current_slot())
+    assert len(store.equivocating_indices) > 0, "Slashing had no effect"
+
+    # is_one_confirmed must still hold
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "Slashing supporters should not break is_one_confirmed"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_slashing_non_supporters_helps(spec, state):
+    """
+    Test that slashing non-supporting equivocators helps is_one_confirmed pass.
+
+    When an equivocator's latest message does not point to block B:
+    - B's support is unchanged (they weren't counting toward it)
+    - Their weight is subtracted from the adversarial budget
+
+    In the inequality: LHS unchanged, RHS drops → strictly helps.
+
+    This models the scenario where adversarial validators are detected as
+    equivocators and their latest visible vote was for a competing branch.
+    Detecting them reduces the adversarial budget without affecting B's
+    observed support, making the safety threshold easier to meet.
+
+    With 64 validators in MINIMAL (8 per committee), at 85% participation
+    is_one_confirmed fails. Slashing non-supporters reduces the adversarial
+    budget enough to flip the predicate to True.
+
+    1. Build block B with 85% participation (is_one_confirmed = False)
+    2. Identify validators whose latest message does not point to B
+    3. Slash those non-supporters
+    4. Verify support unchanged, adversarial budget decreased, is_one_confirmed flips to True
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    # Block B with 85% participation — fails is_one_confirmed
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=85)
+
+    block = store.blocks[block_b]
+    parent_block = store.blocks[block.parent_root]
+    assert parent_block.slot + 1 == block.slot, "Test requires consecutive slots"
+
+    balance_source = spec.get_current_balance_source(store)
+
+    support_before = spec.get_attestation_score(store, block_b, balance_source)
+    adversarial_weight_before = spec.get_adversarial_weight(store, balance_source, block_b)
+
+    assert not spec.is_one_confirmed(store, balance_source, block_b), (
+        "Precondition: is_one_confirmed should fail at 85% participation"
+    )
+
+    # Identify non-supporters: validators whose latest message does not point to B
+    non_supporters = [
+        i for i in range(len(state.validators))
+        if (
+            i not in store.latest_messages
+            or store.latest_messages[i].root != block_b
+        )
+        and not state.validators[i].slashed
+        and i not in store.equivocating_indices
+    ]
+    assert len(non_supporters) > 0, "Need non-supporters to slash"
+
+    # Slash non-supporters
+    slash_count = min(len(non_supporters), len(state.validators) * 25 // 100)
+    fcr.apply_attester_slashing(
+        slashing_indices=non_supporters[:slash_count],
+        slot=fcr.current_slot(),
+    )
+
+    # Support must be unchanged — we only slashed non-voters for B
+    support_after = spec.get_attestation_score(store, block_b, balance_source)
+    assert support_after == support_before, (
+        f"Support changed after slashing non-voters: {support_before} -> {support_after}"
+    )
+
+    # Adversarial budget must have decreased
+    adversarial_weight_after = spec.get_adversarial_weight(store, balance_source, block_b)
+    assert adversarial_weight_after < adversarial_weight_before, (
+        f"Adversarial weight should decrease: {adversarial_weight_before} -> {adversarial_weight_after}"
+    )
+
+    # is_one_confirmed should now pass
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "Slashing non-supporters should help is_one_confirmed pass"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_empty_slot_discount(spec, state):
+    """
+    Test that the empty slot discount correctly compensates for honest
+    validators in skipped-slot committees whose latest vote points to the parent.
+
+    When a block skips slots, honest validators in the skipped committees
+    voted for parent(b) — their votes can't help any sibling of b.
+    The discount credits this weight (minus a conservative β correction)
+    to the LHS of the safety inequality.
+
+    This test verifies:
+    1. A block in a consecutive slot has support_discount == 0
+    2. A block after an empty slot has support_discount > 0
+    3. The discount value equals parent support in empty slots minus
+       adversarial weight in those slots (matching the formula)
+    4. With accumulation, the discount contributes to is_one_confirmed
+       passing for the gapped block
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    # Block A: consecutive slot (no empty slot gap) 
+    block_a = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    block_a_data = store.blocks[block_a]
+    parent_a = store.blocks[block_a_data.parent_root]
+    assert parent_a.slot + 1 == block_a_data.slot, "Block A must be consecutive"
+
+    balance_source = spec.get_current_balance_source(store)
+
+    discount_a = spec.get_support_discount(store, balance_source, block_a)
+    assert discount_a == 0, f"Block A discount should be 0, got {discount_a}"
+
+    assert spec.is_one_confirmed(store, balance_source, block_a), (
+        "Block A should pass is_one_confirmed (consecutive, 100%)"
+    )
+
+    # Block B: after an empty slot gap 
+    head_before_empty = fcr.head()
+
+    # Empty slot: attest 100% to current head, advance, apply, run FCR — no block
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=head_before_empty, participation_rate=100
+    )
+
+    # Propose block after the gap
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(
+        parent_root=head_before_empty, participation_rate=100
+    )
+
+    block_b_data = store.blocks[block_b]
+    parent_b = store.blocks[block_b_data.parent_root]
+    assert parent_b.slot + 1 < block_b_data.slot, "Block B must have an empty slot gap"
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # Discount must be positive
+    discount_b = int(spec.get_support_discount(store, balance_source, block_b))
+    assert discount_b > 0, "Block B discount should be > 0 with empty slot gap"
+
+    # Verify the discount matches the formula:
+    # discount = parent_support_in_empty_slots - adversarial_weight_in_empty_slots
+    parent_support_in_empty = int(spec.get_block_support_between_slots(
+        store, balance_source, block_b_data.parent_root,
+        spec.Slot(parent_b.slot + 1), spec.Slot(block_b_data.slot - 1),
+    ))
+    adv_in_empty = int(spec.compute_adversarial_weight(
+        store, balance_source,
+        spec.Slot(parent_b.slot + 1), spec.Slot(block_b_data.slot - 1),
+    ))
+    assert discount_b == parent_support_in_empty - adv_in_empty, (
+        f"Discount should equal parent_support - adv in empty slots: "
+        f"discount={discount_b}, parent_support={parent_support_in_empty}, adv={adv_in_empty}"
+    )
+
+    # Accumulate support to show discount contributes to confirmation
+    # At this point is_one_confirmed fails for block_b (one slot + empty slot gap).
+    # Accumulate one more slot of attestations to dilute proposer boost.
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=block_b, participation_rate=100
+    )
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # With accumulation, block_b should now pass
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "Block B should pass is_one_confirmed after accumulation"
+    )
+
+    # Verify the discount is still contributing: without it, would it still pass?
+    current_slot = spec.get_current_slot(store)
+    support_b = int(spec.get_attestation_score(store, block_b, balance_source))
+    proposer_b = int(spec.compute_proposer_score(balance_source))
+    total_active_balance = spec.get_total_active_balance(balance_source)
+    max_support_b = int(spec.estimate_committee_weight_between_slots(
+        total_active_balance, spec.Slot(parent_b.slot + 1), spec.Slot(current_slot - 1)
+    ))
+    adv_b = int(spec.get_adversarial_weight(store, balance_source, block_b))
+    discount_b_now = int(spec.get_support_discount(store, balance_source, block_b))
+
+    rhs_b = max_support_b + proposer_b + 2 * adv_b
+    margin_without_discount = 2 * support_b - rhs_b
+    margin_with_discount = 2 * support_b + discount_b_now - rhs_b
+
+    assert margin_with_discount > margin_without_discount, (
+        "Discount should still improve the margin after accumulation"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_support_accumulates_over_slots(spec, state):
+    """
+    Test that is_one_confirmed can flip from False to True as more slots
+    of attestation support accumulate.
+
+    The safety inequality compares support against maximum_support. Both
+    grow as more slots elapse after parent(b), but proposer_score is a
+    fixed constant that doesn't scale with slots. As more committees
+    accumulate, the relative impact of proposer_score shrinks, making
+    confirmation easier.
+
+    At 85% participation with one slot of support, is_one_confirmed fails
+    because the proposer boost is ~40% of one committee's weight. With
+    two slots, the boost drops to ~20% of the total budget, and the
+    accumulated support is enough to satisfy the inequality.
+
+    1. Build block B with 85% attestations, advance to s+1, run FCR
+    2. At s+1: verify is_one_confirmed fails (one slot, boost too large)
+    3. Attest 85% to B at s+1, advance to s+2, run FCR
+    4. At s+2: verify is_one_confirmed passes (boost diluted by second committee)
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    # Propose block B with 85% participation
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=85)
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # At s+1: one slot of support — fails due to proposer boost
+    assert not spec.is_one_confirmed(store, balance_source, block_b), (
+        "is_one_confirmed should fail with one slot of support at 85%"
+    )
+
+    # Attest 85% to B at s+1, advance to s+2, apply, run FCR — no new block
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=block_b, participation_rate=85
+    )
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # At s+2: two slots of support — boost diluted, passes
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "is_one_confirmed should pass with two slots of accumulated support"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_epoch_crossing_block(spec, state):
+    """
+    Test is_one_confirmed for a block that crosses an epoch boundary
+    (parent in epoch e-1, block in epoch e).
+
+    When a block crosses an epoch boundary, get_adversarial_weight uses
+    the first slot of the block's epoch as the start slot instead of the
+    block's own slot. This widens the adversarial budget range to include
+    earlier slots in the epoch.
+
+    1. Build a chain to the last slot of epoch 1
+    2. Propose a block at the second slot of epoch 2 with parent at last slot of epoch 1
+       (crossing the epoch boundary, leaving first slot of epoch 2 empty)
+    3. Verify the block crosses an epoch boundary
+    4. Verify adversarial weight uses epoch start, not block slot
+    5. Check is_one_confirmed with accumulated support
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through most of epoch 1 with full participation
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S - 1, participation_rate=100)
+
+    # We're now at the last slot of epoch 1
+    parent_root = fcr.head()
+    parent_epoch = spec.get_block_epoch(store, parent_root)
+
+    # Skip the first slot of epoch 2 (empty slot at epoch boundary)
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=parent_root, participation_rate=100
+    )
+
+    # Propose block at second slot of epoch 2 — crosses epoch boundary
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(
+        parent_root=parent_root, participation_rate=100
+    )
+
+    block = store.blocks[block_b]
+    block_epoch = spec.get_block_epoch(store, block_b)
+    parent_block = store.blocks[block.parent_root]
+    parent_block_epoch = spec.compute_epoch_at_slot(parent_block.slot)
+
+    # Verify epoch crossing
+    assert block_epoch > parent_block_epoch, (
+        f"Block must cross epoch boundary: block_epoch={block_epoch}, parent_epoch={parent_block_epoch}"
+    )
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # Verify adversarial weight uses epoch start as start_slot
+    current_slot = spec.get_current_slot(store)
+    epoch_start = spec.compute_start_slot_at_epoch(block_epoch)
+
+    # Adversarial weight with epoch start (what the code does for epoch-crossing)
+    adv_from_epoch_start = int(spec.compute_adversarial_weight(
+        store, balance_source, epoch_start, spec.Slot(current_slot - 1)
+    ))
+
+    # Adversarial weight with block slot (what the code would do without epoch-crossing logic)
+    adv_from_block_slot = int(spec.compute_adversarial_weight(
+        store, balance_source, block.slot, spec.Slot(current_slot - 1)
+    ))
+
+    # The actual adversarial weight used by is_one_confirmed
+    adv_actual = int(spec.get_adversarial_weight(store, balance_source, block_b))
+
+    # For epoch-crossing block, adversarial weight must use epoch start
+    assert adv_actual == adv_from_epoch_start, (
+        f"Adversarial weight should use epoch start: actual={adv_actual}, "
+        f"from_epoch_start={adv_from_epoch_start}, from_block_slot={adv_from_block_slot}"
+    )
+
+    # Epoch start range is wider → adversarial budget should be >= block slot range
+    assert adv_from_epoch_start >= adv_from_block_slot, (
+        f"Epoch start range should give >= adversarial weight: "
+        f"epoch_start={adv_from_epoch_start}, block_slot={adv_from_block_slot}"
+    )
+
+    # Accumulate more support to get is_one_confirmed to pass
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=block_b, participation_rate=100
+    )
+
+    balance_source = spec.get_current_balance_source(store)
+
+    assert spec.is_one_confirmed(store, balance_source, block_b), (
+        "Epoch-crossing block should pass is_one_confirmed with accumulated support"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_fails_with_competing_branch(spec, state):
+    """
+    Test that is_one_confirmed fails when support is split between competing blocks.
+
+    This models the core adversarial scenario: two sibling blocks B1 and B2
+    (both children of the same parent) compete for attestation support.
+    When support is split, neither block can accumulate enough to satisfy
+    the safety inequality.
+
+    The test verifies the split is the cause by accumulating additional
+    support exclusively for B1. After enough slots, B1 passes while B2
+    (with no additional votes) remains failed — demonstrating that the
+    fork is resolved in B1's favor once honest validators consolidate.
+
+    1. Build chain to establish balance source
+    2. Create two competing blocks B1 and B2 from the same parent
+    3. Split attestations: ~50% vote for B1, ~50% for B2
+    4. Verify is_one_confirmed fails for both blocks
+    5. Accumulate support for B1 only until it passes
+    6. Verify B2 still fails throughout
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 to establish balance source
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    parent_root = fcr.head()
+
+    # Create two competing sibling blocks from the same parent
+    block_b1 = fcr.add_and_apply_block(parent_root=parent_root)
+    block_b2 = fcr.add_and_apply_block(parent_root=parent_root)
+
+    assert store.blocks[block_b1].parent_root == store.blocks[block_b2].parent_root, (
+        "B1 and B2 must be siblings (same parent)"
+    )
+
+    # Split attestations: ~50% for B1, ~50% for B2
+    fcr.attest(block_root=block_b1, participation_rate=50, include_in_pool=True)
+    fcr.attest(block_root=block_b2, participation_rate=50, include_in_pool=True)
+
+    fcr.next_slot_and_apply_attestations()
+    fcr.run_fast_confirmation()
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # Both must have some support
+    support_b1 = int(spec.get_attestation_score(store, block_b1, balance_source))
+    support_b2 = int(spec.get_attestation_score(store, block_b2, balance_source))
+    assert support_b1 > 0, "B1 should have some support"
+    assert support_b2 > 0, "B2 should have some support"
+
+    # Neither passes with split support
+    assert not spec.is_one_confirmed(store, balance_source, block_b1), (
+        "B1 should fail is_one_confirmed with split support"
+    )
+    assert not spec.is_one_confirmed(store, balance_source, block_b2), (
+        "B2 should fail is_one_confirmed with split support"
+    )
+
+    # Accumulate support for B1 only — first additional slot
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=block_b1, participation_rate=100
+    )
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # B1 still fails after one additional slot (initial split deficit too large)
+    assert not spec.is_one_confirmed(store, balance_source, block_b1), (
+        "B1 should still fail after one additional slot of support"
+    )
+    assert not spec.is_one_confirmed(store, balance_source, block_b2), (
+        "B2 should still fail with no additional support"
+    )
+
+    # Accumulate support for B1 only — second additional slot
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=block_b1, participation_rate=100
+    )
+
+    balance_source = spec.get_current_balance_source(store)
+
+    # B1 now passes — enough accumulated support overcomes the split deficit
+    assert spec.is_one_confirmed(store, balance_source, block_b1), (
+        "B1 should pass is_one_confirmed after sufficient accumulation"
+    )
+
+    # B2 still fails — it never got additional support
+    assert not spec.is_one_confirmed(store, balance_source, block_b2), (
+        "B2 should still fail with no additional support"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_confirmed_chain_safe_passes_full_chain(spec, state):
+    """
+    Test that is_confirmed_chain_safe returns True when the entire chain
+    from the anchor checkpoint to the confirmed block has full participation.
+
+    is_confirmed_chain_safe walks from the confirmed block back to the
+    checkpoint block, checking is_one_confirmed on every block along the
+    way. If any block fails, the whole chain fails. With 100% participation,
+    every block should individually pass, and the chain check should succeed.
+
+    This test verifies:
+    1. confirmed_root advances beyond genesis (FCR confirms blocks)
+    2. The confirmed chain has multiple blocks 
+    3. is_confirmed_chain_safe returns True for the confirmed root
+    4. Every individual block in the chain passes is_one_confirmed
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 2 with 100% participation
+    fcr.run_slots_with_blocks_and_fast_confirmation(3 * S, participation_rate=100)
+
+    confirmed_root = store.confirmed_root
+
+    # Confirmed root must have advanced beyond genesis
+    assert confirmed_root != state.latest_block_header.parent_root, (
+        "confirmed_root should have advanced beyond genesis"
+    )
+
+    # Verify is_confirmed_chain_safe passes
+    assert spec.is_confirmed_chain_safe(store, confirmed_root), (
+        "is_confirmed_chain_safe should pass with 100% participation"
+    )
+
+    # Walk the chain from confirmed_root back toward the anchor and verify
+    # each block individually passes is_one_confirmed
+    balance_source = spec.get_previous_balance_source(store)
+    block_root = confirmed_root
+    anchor_root = store.previous_epoch_observed_justified_checkpoint.root
+    blocks_checked = 0
+
+    while block_root != anchor_root:
+        block = store.blocks[block_root]
+        assert spec.is_one_confirmed(store, balance_source, block_root), (
+            f"Block at slot {block.slot} should individually pass is_one_confirmed"
+        )
+        block_root = block.parent_root
+        blocks_checked += 1
+
+    # The chain should have multiple blocks (non-trivial walk)
+    assert blocks_checked > 1, (
+        f"Expected multi-block chain, only checked {blocks_checked} blocks"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
+    """
+    Implementation-level test for epoch-crossing adversarial range.
+
+    When a block crosses an epoch boundary (parent in epoch e-1, block in
+    epoch e) with an empty slot at epoch start, the adversarial budget must
+    include that empty slot's committee. If the implementation incorrectly
+    used block.slot instead of epoch_start, the adversarial budget would be
+    smaller and the block could be incorrectly confirmed.
+
+    This test engineers a scenario where the margin between correct and
+    incorrect adversarial ranges determines whether is_one_confirmed passes:
+    - With correct range (from epoch_start): FAILS (margin = -102.4B)
+    - With wrong range (from block.slot): WOULD PASS (margin = +25.6B)
+    - The difference is exactly one committee's adversarial contribution (128B)
+
+    The test verifies through confirmed_root that the epoch-crossing block
+    is NOT confirmed — proving the implementation correctly uses the wider
+    adversarial range.
+
+    Setup:
+    1. Build chain through epoch 1 with 100% participation
+    2. Skip first slot of epoch 2 (empty)
+    3. Propose block at slot 17 with parent at slot 15 (epoch crossing)
+    4. Accumulate 85% support for 2 slots
+    5. Verify block is NOT confirmed (correct adversarial range prevents it)
+    6. Verify it WOULD be confirmed with the narrower (incorrect) range
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Build through epoch 1 with full participation
+    fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
+
+    parent_root = fcr.head()
+
+    # Skip first slot of epoch 2 (empty) — attest to parent
+    fcr.attest_and_next_slot_with_fast_confirmation(
+        block_root=parent_root, participation_rate=100
+    )
+
+    # Propose epoch-crossing block at slot 17 with parent at slot 15
+    block_b = fcr.next_slot_with_block_and_fast_confirmation(
+        parent_root=parent_root, participation_rate=85
+    )
+
+    # Verify epoch crossing
+    block = store.blocks[block_b]
+    block_epoch = spec.get_block_epoch(store, block_b)
+    parent_block = store.blocks[block.parent_root]
+    parent_epoch = spec.compute_epoch_at_slot(parent_block.slot)
+    assert block_epoch > parent_epoch, (
+        f"Block must cross epoch boundary: block_epoch={block_epoch}, parent_epoch={parent_epoch}"
+    )
+
+    # Verify there is a gap (empty slot between epoch_start and block.slot)
+    epoch_start = spec.compute_start_slot_at_epoch(block_epoch)
+    assert block.slot > epoch_start, (
+        f"Block must be after epoch start to have a gap: block.slot={block.slot}, epoch_start={epoch_start}"
+    )
+
+    # Accumulate support at 85% for 2 more slots
+    for _ in range(2):
+        fcr.attest_and_next_slot_with_fast_confirmation(
+            block_root=block_b, participation_rate=85
+        )
+
+    balance_source = spec.get_current_balance_source(store)
+    current_slot = spec.get_current_slot(store)
+    total_active_balance = spec.get_total_active_balance(balance_source)
+
+    # Block should NOT be confirmed (correct adversarial range)
+    assert not spec.is_one_confirmed(store, balance_source, block_b), (
+        "Epoch-crossing block should NOT be confirmed with correct adversarial range"
+    )
+
+    # Verify the epoch-crossing logic is what prevents confirmation:
+    # compute margins with correct vs wrong adversarial range
+    adv_correct = int(spec.compute_adversarial_weight(
+        store, balance_source, epoch_start, spec.Slot(current_slot - 1)
+    ))
+    adv_wrong = int(spec.compute_adversarial_weight(
+        store, balance_source, block.slot, spec.Slot(current_slot - 1)
+    ))
+
+    support = int(spec.get_attestation_score(store, block_b, balance_source))
+    max_support = int(spec.estimate_committee_weight_between_slots(
+        total_active_balance,
+        spec.Slot(parent_block.slot + 1),
+        spec.Slot(current_slot - 1),
+    ))
+    proposer = int(spec.compute_proposer_score(balance_source))
+    discount = int(spec.get_support_discount(store, balance_source, block_b))
+
+    lhs = 2 * support + discount
+    rhs_correct = max_support + proposer + 2 * adv_correct
+    rhs_wrong = max_support + proposer + 2 * adv_wrong
+
+    # With correct range: fails (negative margin)
+    assert lhs <= rhs_correct, (
+        f"Should fail with correct adversarial range: lhs={lhs}, rhs={rhs_correct}"
+    )
+
+    # With wrong range: would pass (positive margin)
+    assert lhs > rhs_wrong, (
+        f"Would pass with incorrect adversarial range: lhs={lhs}, rhs={rhs_wrong}"
+    )
+
+    # confirmed_root should NOT include block_b
+    assert store.confirmed_root != block_b, (
+        "confirmed_root should not advance to the epoch-crossing block"
+    )
+
+    yield from fcr.get_test_artefacts()

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_is_one_confirmed.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_is_one_confirmed.py
@@ -16,6 +16,7 @@ from eth2spec.test.helpers.fast_confirmation import (
 Test is_one_confirmed
 """
 
+
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
 @with_custom_state(
@@ -74,11 +75,10 @@ def test_is_one_confirmed_passes_with_full_participation(spec, state):
     # Verify the integer inequality directly
     lhs = 2 * support + support_discount
     rhs = maximum_support + proposer_score + 2 * adversarial_weight
-    assert lhs > rhs, (
-        f"Inequality failed: lhs={lhs} vs rhs={rhs}"
-    )
+    assert lhs > rhs, f"Inequality failed: lhs={lhs} vs rhs={rhs}"
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -139,11 +139,10 @@ def test_is_one_confirmed_fails_with_low_participation(spec, state):
     # Verify the inequality does NOT hold
     lhs = 2 * support + support_discount
     rhs = maximum_support + proposer_score + 2 * adversarial_weight
-    assert lhs <= rhs, (
-        f"Inequality unexpectedly holds: lhs={lhs} > rhs={rhs} at 50% participation"
-    )
+    assert lhs <= rhs, f"Inequality unexpectedly holds: lhs={lhs} > rhs={rhs} at 50% participation"
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -196,6 +195,7 @@ def test_is_one_confirmed_slashing_supporters_does_not_hurt(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -255,11 +255,9 @@ def test_is_one_confirmed_slashing_non_supporters_helps(spec, state):
 
     # Identify non-supporters: validators whose latest message does not point to B
     non_supporters = [
-        i for i in range(len(state.validators))
-        if (
-            i not in store.latest_messages
-            or store.latest_messages[i].root != block_b
-        )
+        i
+        for i in range(len(state.validators))
+        if (i not in store.latest_messages or store.latest_messages[i].root != block_b)
         and not state.validators[i].slashed
         and i not in store.equivocating_indices
     ]
@@ -290,6 +288,7 @@ def test_is_one_confirmed_slashing_non_supporters_helps(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -325,7 +324,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     # Build through epoch 1 to establish balance source
     fcr.run_slots_with_blocks_and_fast_confirmation(2 * S, participation_rate=100)
 
-    # Block A: consecutive slot (no empty slot gap) 
+    # Block A: consecutive slot (no empty slot gap)
     block_a = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     block_a_data = store.blocks[block_a]
@@ -341,7 +340,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
         "Block A should pass is_one_confirmed (consecutive, 100%)"
     )
 
-    # Block B: after an empty slot gap 
+    # Block B: after an empty slot gap
     head_before_empty = fcr.head()
 
     # Empty slot: attest 100% to current head, advance, apply, run FCR — no block
@@ -366,14 +365,23 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
 
     # Verify the discount matches the formula:
     # discount = parent_support_in_empty_slots - adversarial_weight_in_empty_slots
-    parent_support_in_empty = int(spec.get_block_support_between_slots(
-        store, balance_source, block_b_data.parent_root,
-        spec.Slot(parent_b.slot + 1), spec.Slot(block_b_data.slot - 1),
-    ))
-    adv_in_empty = int(spec.compute_adversarial_weight(
-        store, balance_source,
-        spec.Slot(parent_b.slot + 1), spec.Slot(block_b_data.slot - 1),
-    ))
+    parent_support_in_empty = int(
+        spec.get_block_support_between_slots(
+            store,
+            balance_source,
+            block_b_data.parent_root,
+            spec.Slot(parent_b.slot + 1),
+            spec.Slot(block_b_data.slot - 1),
+        )
+    )
+    adv_in_empty = int(
+        spec.compute_adversarial_weight(
+            store,
+            balance_source,
+            spec.Slot(parent_b.slot + 1),
+            spec.Slot(block_b_data.slot - 1),
+        )
+    )
     assert discount_b == parent_support_in_empty - adv_in_empty, (
         f"Discount should equal parent_support - adv in empty slots: "
         f"discount={discount_b}, parent_support={parent_support_in_empty}, adv={adv_in_empty}"
@@ -382,9 +390,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     # Accumulate support to show discount contributes to confirmation
     # At this point is_one_confirmed fails for block_b (one slot + empty slot gap).
     # Accumulate one more slot of attestations to dilute proposer boost.
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=block_b, participation_rate=100
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=100)
 
     balance_source = spec.get_current_balance_source(store)
 
@@ -398,9 +404,11 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     support_b = int(spec.get_attestation_score(store, block_b, balance_source))
     proposer_b = int(spec.compute_proposer_score(balance_source))
     total_active_balance = spec.get_total_active_balance(balance_source)
-    max_support_b = int(spec.estimate_committee_weight_between_slots(
-        total_active_balance, spec.Slot(parent_b.slot + 1), spec.Slot(current_slot - 1)
-    ))
+    max_support_b = int(
+        spec.estimate_committee_weight_between_slots(
+            total_active_balance, spec.Slot(parent_b.slot + 1), spec.Slot(current_slot - 1)
+        )
+    )
     adv_b = int(spec.get_adversarial_weight(store, balance_source, block_b))
     discount_b_now = int(spec.get_support_discount(store, balance_source, block_b))
 
@@ -413,6 +421,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -462,9 +471,7 @@ def test_is_one_confirmed_support_accumulates_over_slots(spec, state):
     )
 
     # Attest 85% to B at s+1, advance to s+2, apply, run FCR — no new block
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=block_b, participation_rate=85
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=85)
 
     balance_source = spec.get_current_balance_source(store)
 
@@ -474,6 +481,7 @@ def test_is_one_confirmed_support_accumulates_over_slots(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -510,12 +518,9 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
 
     # We're now at the last slot of epoch 1
     parent_root = fcr.head()
-    parent_epoch = spec.get_block_epoch(store, parent_root)
 
     # Skip the first slot of epoch 2 (empty slot at epoch boundary)
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=parent_root, participation_rate=100
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=parent_root, participation_rate=100)
 
     # Propose block at second slot of epoch 2 — crosses epoch boundary
     block_b = fcr.next_slot_with_block_and_fast_confirmation(
@@ -539,14 +544,18 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
     epoch_start = spec.compute_start_slot_at_epoch(block_epoch)
 
     # Adversarial weight with epoch start (what the code does for epoch-crossing)
-    adv_from_epoch_start = int(spec.compute_adversarial_weight(
-        store, balance_source, epoch_start, spec.Slot(current_slot - 1)
-    ))
+    adv_from_epoch_start = int(
+        spec.compute_adversarial_weight(
+            store, balance_source, epoch_start, spec.Slot(current_slot - 1)
+        )
+    )
 
     # Adversarial weight with block slot (what the code would do without epoch-crossing logic)
-    adv_from_block_slot = int(spec.compute_adversarial_weight(
-        store, balance_source, block.slot, spec.Slot(current_slot - 1)
-    ))
+    adv_from_block_slot = int(
+        spec.compute_adversarial_weight(
+            store, balance_source, block.slot, spec.Slot(current_slot - 1)
+        )
+    )
 
     # The actual adversarial weight used by is_one_confirmed
     adv_actual = int(spec.get_adversarial_weight(store, balance_source, block_b))
@@ -564,9 +573,7 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
     )
 
     # Accumulate more support to get is_one_confirmed to pass
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=block_b, participation_rate=100
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=100)
 
     balance_source = spec.get_current_balance_source(store)
 
@@ -575,6 +582,7 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -647,9 +655,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     )
 
     # Accumulate support for B1 only — first additional slot
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=block_b1, participation_rate=100
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b1, participation_rate=100)
 
     balance_source = spec.get_current_balance_source(store)
 
@@ -662,9 +668,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     )
 
     # Accumulate support for B1 only — second additional slot
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=block_b1, participation_rate=100
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b1, participation_rate=100)
 
     balance_source = spec.get_current_balance_source(store)
 
@@ -679,6 +683,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -700,7 +705,7 @@ def test_is_confirmed_chain_safe_passes_full_chain(spec, state):
 
     This test verifies:
     1. confirmed_root advances beyond genesis (FCR confirms blocks)
-    2. The confirmed chain has multiple blocks 
+    2. The confirmed chain has multiple blocks
     3. is_confirmed_chain_safe returns True for the confirmed root
     4. Every individual block in the chain passes is_one_confirmed
     """
@@ -740,12 +745,9 @@ def test_is_confirmed_chain_safe_passes_full_chain(spec, state):
         blocks_checked += 1
 
     # The chain should have multiple blocks (non-trivial walk)
-    assert blocks_checked > 1, (
-        f"Expected multi-block chain, only checked {blocks_checked} blocks"
-    )
+    assert blocks_checked > 1, f"Expected multi-block chain, only checked {blocks_checked} blocks"
 
     yield from fcr.get_test_artefacts()
-
 
 
 @with_altair_and_later
@@ -795,9 +797,7 @@ def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
     parent_root = fcr.head()
 
     # Skip first slot of epoch 2 (empty) — attest to parent
-    fcr.attest_and_next_slot_with_fast_confirmation(
-        block_root=parent_root, participation_rate=100
-    )
+    fcr.attest_and_next_slot_with_fast_confirmation(block_root=parent_root, participation_rate=100)
 
     # Propose epoch-crossing block at slot 17 with parent at slot 15
     block_b = fcr.next_slot_with_block_and_fast_confirmation(
@@ -821,9 +821,7 @@ def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
 
     # Accumulate support at 85% for 2 more slots
     for _ in range(2):
-        fcr.attest_and_next_slot_with_fast_confirmation(
-            block_root=block_b, participation_rate=85
-        )
+        fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=85)
 
     balance_source = spec.get_current_balance_source(store)
     current_slot = spec.get_current_slot(store)
@@ -836,19 +834,25 @@ def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
 
     # Verify the epoch-crossing logic is what prevents confirmation:
     # compute margins with correct vs wrong adversarial range
-    adv_correct = int(spec.compute_adversarial_weight(
-        store, balance_source, epoch_start, spec.Slot(current_slot - 1)
-    ))
-    adv_wrong = int(spec.compute_adversarial_weight(
-        store, balance_source, block.slot, spec.Slot(current_slot - 1)
-    ))
+    adv_correct = int(
+        spec.compute_adversarial_weight(
+            store, balance_source, epoch_start, spec.Slot(current_slot - 1)
+        )
+    )
+    adv_wrong = int(
+        spec.compute_adversarial_weight(
+            store, balance_source, block.slot, spec.Slot(current_slot - 1)
+        )
+    )
 
     support = int(spec.get_attestation_score(store, block_b, balance_source))
-    max_support = int(spec.estimate_committee_weight_between_slots(
-        total_active_balance,
-        spec.Slot(parent_block.slot + 1),
-        spec.Slot(current_slot - 1),
-    ))
+    max_support = int(
+        spec.estimate_committee_weight_between_slots(
+            total_active_balance,
+            spec.Slot(parent_block.slot + 1),
+            spec.Slot(current_slot - 1),
+        )
+    )
     proposer = int(spec.compute_proposer_score(balance_source))
     discount = int(spec.get_support_discount(store, balance_source, block_b))
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
@@ -28,18 +28,7 @@ Test on restart to GU
 @single_phase
 def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     """
-    Test that confirmed_root restarts to GU (not finalized) when all conditions are met:
-    1. At epoch start
-    2. GU.epoch + 1 == current_epoch (GU is fresh)
-    3. GU == unrealized_justifications[head]
-    4. slot(confirmed) < slot(block(GU))
-
-    Strategy:
-    - Epochs 0-4: 100% participation, confirmations and justification advance
-    - Last slot of epoch 4: GU sampling happens, then late slashing arrives
-    - Epoch 5 start: reconfirmation fails due to slashed weight
-      * GU (epoch 4) is fresh, slot(finalized) < slot(GU)
-      * → restart to GU instead of staying at finalized
+    DEBUG: Verify restart-to-GU path is actually triggered.
     """
     fcr = FCRTest(spec, seed=1)
     store = fcr.initialize(state)
@@ -54,46 +43,66 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     assert fcr.current_slot() == epoch5_start - 1
     assert store.finalized_checkpoint.epoch >= spec.Epoch(2)
 
+    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
+        f"GU snapshot should be epoch 4, got {store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
+    )
+
+    confirmed_before = store.confirmed_root
+    finalized_root = store.finalized_checkpoint.root
+    assert confirmed_before != finalized_root, (
+        "Precondition: confirmed should be ahead of finalized"
+    )
+
     # Last slot of epoch 4: build block, attest
     block_root = fcr.add_and_apply_block(parent_root=fcr.head())
     lslot_atts = fcr.attest(block_root=block_root, slot=fcr.current_slot(), participation_rate=100)
 
-    # Late slashing arrives during last slot of epoch 4 (before crossing into epoch 5)
+    # Late slashing arrives during last slot of epoch 4
     fcr.apply_attester_slashing(slashing_percentage=50, slot=fcr.current_slot())
 
-    # Cross into epoch 5 atomically: tick + apply attestations
+    # Cross into epoch 5
     fcr.next_slot()
     fcr.apply_attestations(lslot_atts)
 
-    assert fcr.current_slot() == epoch5_start
-    assert spec.is_start_slot_at_epoch(fcr.current_slot())
+    # Before FCR: check reconfirmation status
+    print(f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(store, confirmed_before)}")
+    print(f"confirmed_before slot: {store.blocks[confirmed_before].slot}")
+    print(f"finalized slot: {store.blocks[finalized_root].slot}")
+    print(f"equivocating_indices: {len(store.equivocating_indices)}")
 
-    # Verify preconditions for restart-to-GU
-    confirmed_before = store.confirmed_root
-    gu = store.current_epoch_observed_justified_checkpoint
-    finalized = store.finalized_checkpoint.root
-    head = fcr.head()
-    head_uj = store.unrealized_justifications[head]
-    current_epoch = spec.get_current_store_epoch(store)
-
-    gu_slot = spec.get_block_slot(store, gu.root)
-    finalized_slot = spec.get_block_slot(store, finalized)
-
-    assert gu.epoch + 1 == current_epoch, f"GU not fresh: {gu.epoch} + 1 != {current_epoch}"
-    assert confirmed_before != finalized, "Should have confirmations before FCR"
-    assert gu == head_uj, "GU != head's UJ"
-    assert finalized_slot < gu_slot, f"slot(finalized)={finalized_slot} >= slot(GU)={gu_slot}"
-    assert gu.root != finalized, "GU == finalized (test not meaningful)"
-
-    # Run FCR - should reset due to reconfirmation failure, then restart to GU
     fcr.run_fast_confirmation()
 
-    # Verify restart to GU (not finalized)
-    assert store.confirmed_root == gu.root, "Should restart to GU"
-    assert store.confirmed_root != finalized, "Should NOT stay at finalized"
+    assert fcr.current_slot() == epoch5_start
+    assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
+
+    gu = store.current_epoch_observed_justified_checkpoint
+    current_epoch = spec.get_current_store_epoch(store)
+    finalized_root = store.finalized_checkpoint.root
+
+    print(f"\nAfter FCR:")
+    print(f"gu.epoch: {gu.epoch}, current_epoch: {current_epoch}")
+    print(f"confirmed_root slot: {store.blocks[store.confirmed_root].slot}")
+    print(f"gu.root slot: {store.blocks[gu.root].slot}")
+    print(f"finalized slot: {store.blocks[finalized_root].slot}")
+    print(f"confirmed == gu.root: {store.confirmed_root == gu.root}")
+    print(f"confirmed == finalized: {store.confirmed_root == finalized_root}")
+    print(f"confirmed == confirmed_before: {store.confirmed_root == confirmed_before}")
+
+    assert gu.epoch + 1 == current_epoch, (
+        f"GU should be fresh after rotation: {gu.epoch} + 1 != {current_epoch}"
+    )
+
+    assert store.confirmed_root != confirmed_before, (
+        "Confirmed root should have changed (reconfirmation failed)"
+    )
+    assert store.confirmed_root == gu.root, (
+        f"Should restart to GU root"
+    )
+    assert store.confirmed_root != finalized_root, (
+        "Should NOT stay at finalized"
+    )
 
     yield from fcr.get_test_artefacts()
-
 
 # test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch can be considered
 # also for this test case scenario. See test_revert_finality.py
@@ -136,6 +145,11 @@ def test_fcr_restarts_to_gu_and_confirms_beyond_gu(spec, state):
     assert fcr.current_slot() == epoch5_start - 1
     assert store.finalized_checkpoint.epoch >= spec.Epoch(2)
 
+    # Verify GU snapshot is fresh before crossing
+    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
+        f"GU snapshot should be epoch 4, got {store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
+    )
+
     # Last slot of epoch 4: build block, attest
     block_root = fcr.add_and_apply_block(parent_root=fcr.head())
     lslot_atts = fcr.attest(block_root=block_root, slot=fcr.current_slot(), participation_rate=100)
@@ -149,34 +163,27 @@ def test_fcr_restarts_to_gu_and_confirms_beyond_gu(spec, state):
         )
     )
 
-    # Cross into epoch 5 atomically: tick + apply attestations
+    # Cross into epoch 5 atomically: tick + apply attestations + FCR
     fcr.next_slot()
     fcr.apply_attestations(lslot_atts)
+    fcr.run_fast_confirmation()
 
     assert fcr.current_slot() == epoch5_start
-    assert spec.is_start_slot_at_epoch(fcr.current_slot())
+    assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
-    # Verify preconditions for restart-to-GU
-    confirmed_before = store.confirmed_root
+    # Verify postconditions after FCR (rotation has happened)
     gu = store.current_epoch_observed_justified_checkpoint
     finalized = store.finalized_checkpoint.root
-    head = fcr.head()
-    head_uj = store.unrealized_justifications[head]
     current_epoch = spec.get_current_store_epoch(store)
 
     gu_slot = spec.get_block_slot(store, gu.root)
     finalized_slot = spec.get_block_slot(store, finalized)
 
     assert gu.epoch + 1 == current_epoch, f"GU not fresh: {gu.epoch} + 1 != {current_epoch}"
-    assert confirmed_before != finalized, "Should have confirmations before FCR"
-    assert gu == head_uj, "GU != head's UJ"
-    assert finalized_slot < gu_slot, f"slot(finalized)={finalized_slot} >= slot(GU)={gu_slot}"
     assert gu.root != finalized, "GU == finalized (test not meaningful)"
+    assert finalized_slot < gu_slot, f"slot(finalized)={finalized_slot} >= slot(GU)={gu_slot}"
 
-    # Run FCR - should reset due to reconfirmation failure, then restart to GU
-    fcr.run_fast_confirmation()
-
-    # Verify restart to GU (not finalized)
+    # Verify restart to GU and advance further (not finalized)
     assert store.confirmed_root == expected_confirmed_root_after_restart, (
         "Should restart to GU and advance further"
     )

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
@@ -9,6 +9,7 @@ from eth2spec.test.context import (
     with_presets,
 )
 from eth2spec.test.helpers.fast_confirmation import (
+    debug_print,
     FCRTest,
     SystemRun,
 )
@@ -65,10 +66,12 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     fcr.apply_attestations(lslot_atts)
 
     # Before FCR: check reconfirmation status
-    print(f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(store, confirmed_before)}")
-    print(f"confirmed_before slot: {store.blocks[confirmed_before].slot}")
-    print(f"finalized slot: {store.blocks[finalized_root].slot}")
-    print(f"equivocating_indices: {len(store.equivocating_indices)}")
+    debug_print(
+        f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(store, confirmed_before)}"
+    )
+    debug_print(f"confirmed_before slot: {store.blocks[confirmed_before].slot}")
+    debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
+    debug_print(f"equivocating_indices: {len(store.equivocating_indices)}")
 
     fcr.run_fast_confirmation()
 
@@ -79,14 +82,14 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     current_epoch = spec.get_current_store_epoch(store)
     finalized_root = store.finalized_checkpoint.root
 
-    print(f"\nAfter FCR:")
-    print(f"gu.epoch: {gu.epoch}, current_epoch: {current_epoch}")
-    print(f"confirmed_root slot: {store.blocks[store.confirmed_root].slot}")
-    print(f"gu.root slot: {store.blocks[gu.root].slot}")
-    print(f"finalized slot: {store.blocks[finalized_root].slot}")
-    print(f"confirmed == gu.root: {store.confirmed_root == gu.root}")
-    print(f"confirmed == finalized: {store.confirmed_root == finalized_root}")
-    print(f"confirmed == confirmed_before: {store.confirmed_root == confirmed_before}")
+    debug_print("\nAfter FCR:")
+    debug_print(f"gu.epoch: {gu.epoch}, current_epoch: {current_epoch}")
+    debug_print(f"confirmed_root slot: {store.blocks[store.confirmed_root].slot}")
+    debug_print(f"gu.root slot: {store.blocks[gu.root].slot}")
+    debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
+    debug_print(f"confirmed == gu.root: {store.confirmed_root == gu.root}")
+    debug_print(f"confirmed == finalized: {store.confirmed_root == finalized_root}")
+    debug_print(f"confirmed == confirmed_before: {store.confirmed_root == confirmed_before}")
 
     assert gu.epoch + 1 == current_epoch, (
         f"GU should be fresh after rotation: {gu.epoch} + 1 != {current_epoch}"
@@ -95,14 +98,11 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     assert store.confirmed_root != confirmed_before, (
         "Confirmed root should have changed (reconfirmation failed)"
     )
-    assert store.confirmed_root == gu.root, (
-        f"Should restart to GU root"
-    )
-    assert store.confirmed_root != finalized_root, (
-        "Should NOT stay at finalized"
-    )
+    assert store.confirmed_root == gu.root, "Should restart to GU root"
+    assert store.confirmed_root != finalized_root, "Should NOT stay at finalized"
 
     yield from fcr.get_test_artefacts()
+
 
 # test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch can be considered
 # also for this test case scenario. See test_revert_finality.py

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_revert_finality.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_revert_finality.py
@@ -718,9 +718,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     # Check GU snapshot = (C, 2) — use the snapshot field, not current_observed
     # (rotation hasn't happened yet, it happens at epoch 4 start inside FCR)
     gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
-    assert gu_snapshot.root == c_red, (
-        "GU snapshot should point to c_red"
-    )
+    assert gu_snapshot.root == c_red, "GU snapshot should point to c_red"
     assert gu_snapshot.epoch == spec.Epoch(2)
 
     # NOW release b' with epoch 3 attestations → justifies (d_root, 3)
@@ -754,9 +752,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     confirmed_epoch = spec.get_block_epoch(store, confirmed_before_fcr)
 
     # bcand is NOT too old (epoch(bcand) + 1 >= current_epoch)
-    assert not (confirmed_epoch + 1 < current_epoch), (
-        "bcand should NOT be too old"
-    )
+    assert not (confirmed_epoch + 1 < current_epoch), "bcand should NOT be too old"
 
     # bcand IS on the canonical chain (bcand ≼ head)
     head_before_fcr = fcr.head()
@@ -767,7 +763,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     # Run FCR — rotation happens, then reset check
     fcr.run_fast_confirmation()
 
-    # Verify GU after rotation      
+    # Verify GU after rotation
     gu = store.current_epoch_observed_justified_checkpoint
     assert gu.root == c_red, "GU should be c_red after rotation"
     assert gu.epoch == spec.Epoch(2)

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_revert_finality.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_revert_finality.py
@@ -616,7 +616,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
       * Global UJ stays (C, 2) due to "first received wins"
     - Epoch 3: BLACK branch continues with 100% participation, confirmations advance
     - Epoch 3 last slot:
-      * FCR runs → GU sampled = (C, 2)
+      * GU snapshot taken = (C, 2)
       * THEN BLACK block b' released with epoch 3 attestations → justifies (d, 3)
     - Epoch 4: justified = (d, 3) so BLACK is canonical, but GU = (C, 2)
       * bcand (BLACK, epoch 3) ⊁ GU (C, epoch 2) → RESET
@@ -711,14 +711,17 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
             parent_root=black_tip, graffiti=f"black_e3_{fcr.current_slot()}", include_atts=False
         )
 
-    # Last slot of epoch 3: First run FCR (GU sampling), THEN release b'
+    # Last slot of epoch 3
     assert fcr.current_slot() == epoch4_start - 1
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1))
 
-    # Check GU = (C, 2)
-    gu = store.current_epoch_observed_justified_checkpoint
-    assert gu.root == c_red
-    assert gu.epoch == spec.Epoch(2)
+    # Check GU snapshot = (C, 2) — use the snapshot field, not current_observed
+    # (rotation hasn't happened yet, it happens at epoch 4 start inside FCR)
+    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
+    assert gu_snapshot.root == c_red, (
+        "GU snapshot should point to c_red"
+    )
+    assert gu_snapshot.epoch == spec.Epoch(2)
 
     # NOW release b' with epoch 3 attestations → justifies (d_root, 3)
     b_prime = fcr.add_and_apply_block(
@@ -732,9 +735,9 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     assert uj_of_b_prime.root == epoch3_black_checkpoint
     assert spec.is_ancestor(store, uj_of_b_prime.root, c_double_prime)
 
-    # GU should STILL be (C, 2)
-    assert store.current_epoch_observed_justified_checkpoint.root == c_red
-    assert store.current_epoch_observed_justified_checkpoint.epoch == spec.Epoch(2)
+    # GU snapshot should STILL be (C, 2) — releasing b' doesn't change it
+    assert store.previous_epoch_greatest_unrealized_checkpoint.root == c_red
+    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(2)
 
     fcr.attest(block_root=b_prime, slot=fcr.current_slot(), participation_rate=100)
 
@@ -743,32 +746,40 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     fcr.apply_attestations()
 
     assert fcr.current_slot() == epoch4_start
-    assert spec.is_start_slot_at_epoch(fcr.current_slot())
+    assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
-    # Verify preconditions: reset is due to bcand ⊁ GU
-    head_before_fcr = fcr.head()
+    # Verify preconditions BEFORE FCR
     confirmed_before_fcr = store.confirmed_root
     current_epoch = spec.get_current_store_epoch(store)
-    gu_root = store.current_epoch_observed_justified_checkpoint.root
     confirmed_epoch = spec.get_block_epoch(store, confirmed_before_fcr)
 
-    bcand_too_old = confirmed_epoch + 1 < current_epoch
-    bcand_not_canonical = not spec.is_ancestor(store, head_before_fcr, confirmed_before_fcr)
-    bcand_not_descendant_of_gu = not spec.is_ancestor(store, confirmed_before_fcr, gu_root)
+    # bcand is NOT too old (epoch(bcand) + 1 >= current_epoch)
+    assert not (confirmed_epoch + 1 < current_epoch), (
+        "bcand should NOT be too old"
+    )
 
-    # These must be FALSE - otherwise reset would be due to these, not bcand ⊁ GU
-    assert not bcand_too_old, "bcand should NOT be too old"
-    assert not bcand_not_canonical, "bcand should be canonical"
+    # bcand IS on the canonical chain (bcand ≼ head)
+    head_before_fcr = fcr.head()
+    assert spec.is_ancestor(store, head_before_fcr, confirmed_before_fcr), (
+        "bcand should be canonical"
+    )
 
-    # This must be TRUE - this is what triggers the reset
-    assert bcand_not_descendant_of_gu, "bcand should NOT be descendant of GU"
-
-    # Run FCR and verify reset
+    # Run FCR — rotation happens, then reset check
     fcr.run_fast_confirmation()
 
+    # Verify GU after rotation      
+    gu = store.current_epoch_observed_justified_checkpoint
+    assert gu.root == c_red, "GU should be c_red after rotation"
+    assert gu.epoch == spec.Epoch(2)
+
+    # Verify bcand is NOT a descendant of GU — this is what triggers the reset
+    assert not spec.is_ancestor(store, confirmed_before_fcr, gu.root), (
+        "bcand should NOT be descendant of GU — this triggers the reset"
+    )
+
+    # Verify reset to finalized
     confirmed_after_fcr = store.confirmed_root
     finalized = store.finalized_checkpoint.root
-
     assert confirmed_after_fcr == finalized, (
         "confirmed_root should reset to finalized due to bcand ⊁ GU"
     )

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_variables.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_variables.py
@@ -146,8 +146,7 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
 
     # After last slot: GU snapshot is taken into previous_epoch_greatest_unrealized_checkpoint
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint
-        == store.unrealized_justified_checkpoint
+        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
     ), "previous_epoch_greatest_unrealized_checkpoint should snapshot unrealized at last slot"
 
     # But observed checkpoints should NOT have rotated yet
@@ -183,6 +182,7 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -259,9 +259,9 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
         assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
         # Verify rotation happened correctly
-        assert store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation, (
-            f"At epoch {epoch + 1} start: previous_observed != old current_observed"
-        )
+        assert (
+            store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation
+        ), f"At epoch {epoch + 1} start: previous_observed != old current_observed"
         assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
             f"At epoch {epoch + 1} start: current_observed != GU snapshot from last slot"
         )
@@ -464,6 +464,7 @@ def test_gu_snapshot_initialization_and_stability(spec, state):
 
     yield from fcr.get_test_artefacts()
 
+
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
 @with_custom_state(
@@ -474,16 +475,16 @@ def test_gu_snapshot_initialization_and_stability(spec, state):
 @single_phase
 def test_observed_justified_stable_during_last_slot(spec, state):
     """
-    At the last slot of an epoch, the observed justified checkpoints used by is_one_confirmed must still 
+    At the last slot of an epoch, the observed justified checkpoints used by is_one_confirmed must still
     reflect the old values, not the new ones.
 
     Concretely: run from epoch start through the entire epoch. Record the
     observed values at the second-to-last slot. Verify they are identical
     at the last slot.
 
-    It verifies that current_epoch_observed_justified_checkpoint and 
-    previous_epoch_observed_justified_checkpoint have the same value at the 
-    last slot of the epoch as they did at the first slot 
+    It verifies that current_epoch_observed_justified_checkpoint and
+    previous_epoch_observed_justified_checkpoint have the same value at the
+    last slot of the epoch as they did at the first slot
     """
     fcr = FCRTest(spec, seed=1)
     store = fcr.initialize(state)
@@ -518,8 +519,7 @@ def test_observed_justified_stable_during_last_slot(spec, state):
 
     # But the GU snapshot should have been taken
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint
-        == store.unrealized_justified_checkpoint
+        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
     ), "GU snapshot should be taken at last slot even though observed checkpoints don't rotate"
 
     yield from fcr.get_test_artefacts()

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_variables.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_variables.py
@@ -72,12 +72,16 @@ def test_fcr_invariants_monotone_and_canonical(spec, state):
 def test_observed_justified_checkpoints_update_timing(spec, state):
     """
     Test the timing of observed justified checkpoint updates:
+
     1. At genesis, both current_epoch_observed_justified_checkpoint and
-     previous_epoch_observed_justified_checkpoint equal the anchor checkpoint
-    2. During mid-epoch slots, observed checkpoints are NOT updated
-    3. At the last slot of an epoch, observed checkpoints ARE updated:
-       - previous_epoch_observed := current_epoch_observed
-       - current_epoch_observed := unrealized_justified_checkpoint
+       previous_epoch_observed_justified_checkpoint equal the anchor checkpoint
+    2. At the last slot of epoch e, only the GU snapshot is taken:
+       previous_epoch_greatest_unrealized_checkpoint := unrealized_justified_checkpoint
+       (observed checkpoints do NOT rotate yet)
+    3. At the first slot of epoch e+1, observed checkpoints ARE rotated:
+       previous_epoch_observed := current_epoch_observed
+       current_epoch_observed := previous_epoch_greatest_unrealized_checkpoint
+    4. During other mid-epoch slots, nothing changes
     """
     fcr = FCRTest(spec, seed=1)
     store = fcr.initialize(state)
@@ -93,25 +97,28 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
     assert store.current_epoch_observed_justified_checkpoint.root == anchor_root
     assert store.current_epoch_observed_justified_checkpoint.epoch == anchor_epoch
 
-    # Run through epoch 0 to get to epoch 2
+    # Run through epochs 0 and 1 to get to epoch 2
     while fcr.current_slot() < 2 * S:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     assert fcr.current_slot() == 2 * S  # First slot of epoch 2
 
     # 2. Check mid-epoch slots don't update observed checkpoints
-    # Record values at start of epoch 2
+    # Record values at start of epoch 2 (rotation just happened here)
     prev_at_epoch2_start = store.previous_epoch_observed_justified_checkpoint
     curr_at_epoch2_start = store.current_epoch_observed_justified_checkpoint
 
-    # Run through mid-epoch slots (slots 1 to S-2 within epoch 1)
+    # Run through mid-epoch slots of epoch 2 (not last slot, not first slot of next epoch)
     last_slot_of_epoch2 = 3 * S - 1
     while fcr.current_slot() < last_slot_of_epoch2 - 1:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-        # Should NOT be a GU sampling slot
+        # Should NOT be either a GU sampling slot or an epoch start
+        assert not spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot())), (
+            f"Slot {fcr.current_slot()} should not be an epoch start"
+        )
         assert not spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1)), (
-            f"Slot {fcr.current_slot()} should not trigger GU sampling"
+            f"Slot {fcr.current_slot()} should not be the last slot of an epoch"
         )
 
         # Observed checkpoints should NOT have changed
@@ -122,32 +129,60 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
             f"current_epoch_observed changed at mid-epoch slot {fcr.current_slot()}"
         )
 
-    # 3. Check last slot of epoch DOES update observed checkpoints
+    # 3. Check last slot of epoch 2: GU snapshot taken, but NO rotation of observed checkpoints
     assert fcr.current_slot() == last_slot_of_epoch2 - 1
 
-    # Record state before the critical slot
+    # Record state before the last slot
+    prev_before_last_slot = store.previous_epoch_observed_justified_checkpoint
     curr_before_last_slot = store.current_epoch_observed_justified_checkpoint
 
-    # Advance to last slot of epoch 1 and run FCR
+    # Advance to last slot of epoch 2
     fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     assert fcr.current_slot() == last_slot_of_epoch2
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1)), (
-        f"Slot {fcr.current_slot()} should trigger GU sampling (next slot is epoch start)"
+        f"Slot {fcr.current_slot()} should be the last slot of the epoch"
     )
 
-    # After update_fast_confirmation_variables runs:
-    # - previous_epoch_observed should now equal what current_epoch_observed was
-    # - current_epoch_observed should now equal unrealized_justified_checkpoint
-    assert store.previous_epoch_observed_justified_checkpoint == curr_before_last_slot, (
-        "previous_epoch_observed should have been set to old current_epoch_observed"
-    )
+    # After last slot: GU snapshot is taken into previous_epoch_greatest_unrealized_checkpoint
     assert (
-        store.current_epoch_observed_justified_checkpoint == store.unrealized_justified_checkpoint
-    ), "current_epoch_observed should equal unrealized_justified_checkpoint after sampling"
+        store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
+    ), "previous_epoch_greatest_unrealized_checkpoint should snapshot unrealized at last slot"
+
+    # But observed checkpoints should NOT have rotated yet
+    assert store.previous_epoch_observed_justified_checkpoint == prev_before_last_slot, (
+        "previous_epoch_observed should NOT change at last slot of epoch"
+    )
+    assert store.current_epoch_observed_justified_checkpoint == curr_before_last_slot, (
+        "current_epoch_observed should NOT change at last slot of epoch"
+    )
+
+    # 4. Check first slot of epoch 3: NOW the rotation happens
+    # Record the snapshot and current_observed before crossing the boundary
+    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
+    curr_before_epoch_start = store.current_epoch_observed_justified_checkpoint
+
+    # Advance to first slot of epoch 3
+    fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    first_slot_of_epoch3 = 3 * S
+    assert fcr.current_slot() == first_slot_of_epoch3
+    assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot())), (
+        f"Slot {fcr.current_slot()} should be the first slot of the epoch"
+    )
+
+    # After epoch start: observed checkpoints rotate
+    # previous_observed := old current_observed
+    assert store.previous_epoch_observed_justified_checkpoint == curr_before_epoch_start, (
+        "previous_epoch_observed should now equal what current_epoch_observed was before rotation"
+    )
+    # current_observed := the GU snapshot taken at the last slot of the previous epoch
+    assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+        "current_epoch_observed should now equal the GU snapshot from last slot of previous epoch"
+    )
 
     yield from fcr.get_test_artefacts()
-
 
 @with_altair_and_later
 @with_presets([MINIMAL], reason="too slow")
@@ -159,12 +194,15 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
 @single_phase
 def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
     """
-    Test properties of observed justified checkpoints across multiple epochs:
 
-    1. At each epoch boundary, previous := current, current := unrealized
-    2. Observed checkpoint epochs never decrease under full participation
-    3. current_observed equals unrealized at sampling moment (last slot of epoch)
-    4. previous_observed is always one epoch behind current_observed
+    1. At the last slot of epoch e, the GU snapshot is taken:
+       previous_epoch_greatest_unrealized_checkpoint := unrealized_justified_checkpoint
+    2. At the first slot of epoch e+1, observed checkpoints rotate:
+       previous_observed := current_observed
+       current_observed := previous_epoch_greatest_unrealized_checkpoint
+    3. Observed checkpoint epochs never decrease under full participation
+    4. The cascade holds: previous_observed at epoch e+1 start ==
+       current_observed at epoch e start
     """
     fcr = FCRTest(spec, seed=1)
     store = fcr.initialize(state)
@@ -174,69 +212,98 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
     prev_current_observed_epoch = store.current_epoch_observed_justified_checkpoint.epoch
     prev_previous_observed_epoch = store.previous_epoch_observed_justified_checkpoint.epoch
 
-    observed_history = []
+    # Records sampled at the first slot of each epoch (where rotation happens)
+    observed_at_epoch_start = []
 
     for epoch in range(4):  # Run through epochs 0, 1, 2, 3
         last_slot = (epoch + 1) * S - 1
+        first_slot_next_epoch = (epoch + 1) * S
 
         # Run to last slot of this epoch
         while fcr.current_slot() < last_slot:
             fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-            # Observed checkpoint epochs never decrease under full participation -- check at every slot
+            # Observed checkpoint epochs never decrease under full participation
             current_observed_epoch = store.current_epoch_observed_justified_checkpoint.epoch
             previous_observed_epoch = store.previous_epoch_observed_justified_checkpoint.epoch
 
             assert current_observed_epoch >= prev_current_observed_epoch, (
-                f"current_epoch_observed went backwards: {prev_current_observed_epoch} -> {current_observed_epoch}"
+                f"current_epoch_observed went backwards: "
+                f"{prev_current_observed_epoch} -> {current_observed_epoch}"
             )
             assert previous_observed_epoch >= prev_previous_observed_epoch, (
-                f"previous_epoch_observed went backwards: {prev_previous_observed_epoch} -> {previous_observed_epoch}"
+                f"previous_epoch_observed went backwards: "
+                f"{prev_previous_observed_epoch} -> {previous_observed_epoch}"
             )
 
             prev_current_observed_epoch = current_observed_epoch
             prev_previous_observed_epoch = previous_observed_epoch
 
-        # Now at last slot of epoch
+        # Now at last slot of epoch — verify GU snapshot is taken
         assert fcr.current_slot() == last_slot
         assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1))
 
-        # === Current_observed equals unrealized at sampling moment
         assert (
-            store.current_epoch_observed_justified_checkpoint
+            store.previous_epoch_greatest_unrealized_checkpoint
             == store.unrealized_justified_checkpoint
-        ), f"At epoch {epoch} last slot: current_observed != unrealized"
+        ), f"At epoch {epoch} last slot: GU snapshot != unrealized"
 
-        # Record for cascade check
-        observed_history.append(
+        # Record the GU snapshot and current_observed before rotation
+        gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
+        curr_observed_before_rotation = store.current_epoch_observed_justified_checkpoint
+
+        # Advance to first slot of next epoch — rotation happens here
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+        assert fcr.current_slot() == first_slot_next_epoch
+        assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
+
+        # Verify rotation happened correctly
+        assert store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation, (
+            f"At epoch {epoch + 1} start: previous_observed != old current_observed"
+        )
+        assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+            f"At epoch {epoch + 1} start: current_observed != GU snapshot from last slot"
+        )
+
+        # Monotonicity check continues through epoch start
+        current_observed_epoch = store.current_epoch_observed_justified_checkpoint.epoch
+        previous_observed_epoch = store.previous_epoch_observed_justified_checkpoint.epoch
+
+        assert current_observed_epoch >= prev_current_observed_epoch, (
+            f"current_epoch_observed went backwards at epoch start: "
+            f"{prev_current_observed_epoch} -> {current_observed_epoch}"
+        )
+        assert previous_observed_epoch >= prev_previous_observed_epoch, (
+            f"previous_epoch_observed went backwards at epoch start: "
+            f"{prev_previous_observed_epoch} -> {previous_observed_epoch}"
+        )
+
+        prev_current_observed_epoch = current_observed_epoch
+        prev_previous_observed_epoch = previous_observed_epoch
+
+        # Record state at epoch start for cascade check
+        observed_at_epoch_start.append(
             {
-                "epoch": epoch,
-                "previous_observed_epoch": int(
-                    store.previous_epoch_observed_justified_checkpoint.epoch
-                ),
-                "current_observed_epoch": int(
-                    store.current_epoch_observed_justified_checkpoint.epoch
-                ),
+                "epoch": epoch + 1,
+                "previous_observed": store.previous_epoch_observed_justified_checkpoint,
                 "current_observed": store.current_epoch_observed_justified_checkpoint,
+                "previous_observed_epoch": int(previous_observed_epoch),
+                "current_observed_epoch": int(current_observed_epoch),
             }
         )
 
-    # At epoch E's last slot, previous_observed should equal what current_observed was at epoch E-1's last slot
-    for i in range(1, len(observed_history)):
-        prev_record = observed_history[i - 1]
-        curr_record = observed_history[i]
+    # at epoch e+1 start, previous_observed should equal
+    # what current_observed was at epoch e start
+    for i in range(1, len(observed_at_epoch_start)):
+        prev_record = observed_at_epoch_start[i - 1]
+        curr_record = observed_at_epoch_start[i]
 
-        assert curr_record["previous_observed_epoch"] == prev_record["current_observed_epoch"], (
-            f"Cascade broken at epoch {curr_record['epoch']}: "
+        assert curr_record["previous_observed"] == prev_record["current_observed"], (
+            f"Cascade broken at epoch {curr_record['epoch']} start: "
             f"previous_observed={curr_record['previous_observed_epoch']} "
             f"but prior current_observed was {prev_record['current_observed_epoch']}"
         )
-
-    # previous_observed at epoch 2 end should equal current_observed at epoch 1 end
-    assert (
-        store.previous_epoch_observed_justified_checkpoint
-        == observed_history[2]["current_observed"]
-    ), "previous_observed at epoch 3 end should equal current_observed at epoch 2 end"
 
     yield from fcr.get_test_artefacts()
 
@@ -324,5 +391,135 @@ def test_slot_head_variables_updated_every_slot(spec, state):
 
         # Update tracking for next iteration
         curr_slot_head_before = actual_current
+
+    yield from fcr.get_test_artefacts()
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_gu_snapshot_initialization_and_stability(spec, state):
+    """
+    Test properties of previous_epoch_greatest_unrealized_checkpoint:
+
+    1. At genesis, it equals the anchor checkpoint (same as other observed variables)
+    2. It is only updated at the last slot of an epoch (GU sampling moment)
+    3. Between the snapshot (last slot of epoch e) and the rotation (first slot
+       of epoch e+1), the snapshot value remains stable even if
+       unrealized_justified_checkpoint changes due to epoch processing
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # 1. Check initialization — should equal anchor checkpoint at genesis
+    anchor_checkpoint = store.finalized_checkpoint
+    assert store.previous_epoch_greatest_unrealized_checkpoint == anchor_checkpoint, (
+        "previous_epoch_greatest_unrealized_checkpoint should equal anchor at genesis"
+    )
+
+    # Run through epoch 0 into epoch 1
+    while fcr.current_slot() < S:
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Now at first slot of epoch 1 — run mid-epoch and verify snapshot doesn't change
+    gu_snapshot_after_epoch0 = store.previous_epoch_greatest_unrealized_checkpoint
+
+    last_slot_of_epoch1 = 2 * S - 1
+    while fcr.current_slot() < last_slot_of_epoch1 - 1:
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+        # 2. Snapshot should NOT change during mid-epoch slots
+        assert store.previous_epoch_greatest_unrealized_checkpoint == gu_snapshot_after_epoch0, (
+            f"GU snapshot changed at mid-epoch slot {fcr.current_slot()}"
+        )
+
+    # Advance to last slot of epoch 1 — new snapshot is taken
+    fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+    assert fcr.current_slot() == last_slot_of_epoch1
+
+    # 3. Snapshot should now reflect the current unrealized_justified_checkpoint
+    snapshot_at_last_slot = store.previous_epoch_greatest_unrealized_checkpoint
+    assert snapshot_at_last_slot == store.unrealized_justified_checkpoint, (
+        "GU snapshot should equal unrealized at last slot of epoch"
+    )
+
+    # Record snapshot before crossing into next epoch
+    snapshot_before_epoch_start = store.previous_epoch_greatest_unrealized_checkpoint
+
+    # Advance to first slot of epoch 2 — epoch processing may advance unrealized
+    fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+    assert fcr.current_slot() == 2 * S
+
+    # The rotation should use the snapshot value, NOT the (possibly updated) unrealized
+    assert store.current_epoch_observed_justified_checkpoint == snapshot_before_epoch_start, (
+        "Rotation should use the GU snapshot, not the live unrealized_justified_checkpoint"
+    )
+
+    yield from fcr.get_test_artefacts()
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_observed_justified_stable_during_last_slot(spec, state):
+    """
+    At the last slot of an epoch, the observed justified checkpoints used by is_one_confirmed must still 
+    reflect the old values, not the new ones.
+
+    Concretely: run from epoch start through the entire epoch. Record the
+    observed values at the second-to-last slot. Verify they are identical
+    at the last slot.
+
+    It verifies that current_epoch_observed_justified_checkpoint and 
+    previous_epoch_observed_justified_checkpoint have the same value at the 
+    last slot of the epoch as they did at the first slot 
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Run to epoch 2 to have meaningful justified checkpoints
+    while fcr.current_slot() < 2 * S:
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Now at first slot of epoch 2 — record observed checkpoints
+    curr_observed_at_epoch_start = store.current_epoch_observed_justified_checkpoint
+    prev_observed_at_epoch_start = store.previous_epoch_observed_justified_checkpoint
+
+    # Run through the entire epoch, all the way to the last slot
+    last_slot_of_epoch2 = 3 * S - 1
+    while fcr.current_slot() < last_slot_of_epoch2:
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    assert fcr.current_slot() == last_slot_of_epoch2
+
+    # Observed checkpoints must be the same as at epoch start
+    # This is what the old code got wrong — it would have rotated them here
+    assert store.current_epoch_observed_justified_checkpoint == curr_observed_at_epoch_start, (
+        "current_epoch_observed must remain stable throughout the entire epoch "
+        "(including the last slot)"
+    )
+    assert store.previous_epoch_observed_justified_checkpoint == prev_observed_at_epoch_start, (
+        "previous_epoch_observed must remain stable throughout the entire epoch "
+        "(including the last slot)"
+    )
+
+    # But the GU snapshot should have been taken
+    assert (
+        store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
+    ), "GU snapshot should be taken at last slot even though observed checkpoints don't rotate"
 
     yield from fcr.get_test_artefacts()


### PR DESCRIPTION
### Problem
`current_epoch_observed_justified_checkpoint` was updated at the start of the last slot of an epoch which is too early as then a new value of that variable is used by `is_one_confirmed` function in that same slot which deviates from the original algorithm behaviour, where the switch must happen in the first slot of a new epoch.

### Solution
* Introduce `previous_epoch_greatest_unrealized_checkpoint` variable to keep the greatest unrealized checkpoint in the view at the start of the last slot of the previous epoch
* Update `*_observed_justified_checkpoint` variables at the start of an epoch

### Rationale

The current design attempts to encapsulate fast confirmation variable management into a single `update_fast_confirmation_variables ` function. To reduce a number of variables we need to move some of the variable updates to `get_latest_confirmed`.

### ToDo
* [x] Update tests