### PR TITLE
Fast Confirmation: Trigger algorithm at after a block or at the attestation deadline

### DIFF
--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -917,9 +917,10 @@ of a slot after attestations from past slots have been applied and before
 `get_attestation_due_ms(epoch)` milliseconds has transpired since the start of
 the slot.
 
-Implementations MAY call `update_fast_confirmation_variables` when a valid block
-from the expected block proposer for the assigned `slot` has been received and
-processed.
+Implementations MAY call `update_fast_confirmation_variables` after a valid
+block from the expected block proposer for the assigned `slot` has been received
+and processed if this happens before `get_attestation_due_ms(epoch)`
+milliseconds has transpired since the start of the `slot`.
 
 Implementations MAY call `get_latest_confirmed` at any point in time throughout
 a slot.

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -912,14 +912,14 @@ Implementations MUST strictly follow the call sequence:
 1. `update_fast_confirmation_variables`
 2. `get_latest_confirmed`
 
-Implementations SHOULD call `update_fast_confirmation_variables` when either (a)
-a valid block from the expected block proposer for the assigned `slot` has been
-received and processed or (b) `get_attestation_due_ms(epoch)` milliseconds has
-transpired since the start of the slot -- whichever comes first.
+Implementations MUST call `update_fast_confirmation_variables` in the first part
+of a slot after attestations from past slots have been applied and before
+`get_attestation_due_ms(epoch)` milliseconds has transpired since the start of
+the slot.
 
-Implementations MUST NOT call `update_fast_confirmation_variables` later than
-`get_attestation_due_ms(epoch)` milliseconds into a slot. Otherwise, the
-synchrony assumption that the algorithm relies upon may not hold.
+Implementations MAY call `update_fast_confirmation_variables` when a valid block
+from the expected block proposer for the assigned `slot` has been received and
+processed.
 
 Implementations MAY call `get_latest_confirmed` at any point in time throughout
 a slot.

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -42,7 +42,7 @@
     - [`find_latest_confirmed_descendant`](#find_latest_confirmed_descendant)
     - [`get_latest_confirmed`](#get_latest_confirmed)
   - [Handlers](#handlers)
-    - [`on_slot_start_after_past_attestations_applied`](#on_slot_start_after_past_attestations_applied)
+    - [`on_fast_confirmation`](#on_fast_confirmation)
 
 <!-- mdformat-toc end -->
 
@@ -899,7 +899,7 @@ def get_latest_confirmed(store: Store) -> Root:
 
 ### Handlers
 
-#### `on_slot_start_after_past_attestations_applied`
+#### `on_fast_confirmation`
 
 *Notes:*
 
@@ -912,15 +912,20 @@ Implementations MUST strictly follow the call sequence:
 1. `update_fast_confirmation_variables`
 2. `get_latest_confirmed`
 
-Implementations MUST call `update_fast_confirmation_variables` at the start of a
-slot after attestations from past slots have been applied. Otherwise, the
+Implementations SHOULD call `update_fast_confirmation_variables` when either (a)
+a valid block from the expected block proposer for the assigned `slot` has been
+received and processed or (b) `get_attestation_due_ms(epoch)` milliseconds has
+transpired since the start of the slot -- whichever comes first.
+
+Implementations MUST NOT call `update_fast_confirmation_variables` later than
+`get_attestation_due_ms(epoch)` milliseconds into a slot. Otherwise, the
 synchrony assumption that the algorithm relies upon may not hold.
 
 Implementations MAY call `get_latest_confirmed` at any point in time throughout
 a slot.
 
 ```python
-def on_slot_start_after_past_attestations_applied(store: Store) -> None:
+def on_fast_confirmation(store: Store) -> None:
     update_fast_confirmation_variables(store)
     store.confirmed_root = get_latest_confirmed(store)
 ```

--- a/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
@@ -57,8 +57,8 @@ def output_fast_confirmation_checks(spec, store, test_steps):
     test_steps.append({"checks": basic_checks | fcr_checks})
 
 
-def on_slot_start_after_past_attestations_applied_and_append_step(spec, store, test_steps):
-    spec.on_slot_start_after_past_attestations_applied(store)
+def on_fast_confirmation_and_append_step(spec, store, test_steps):
+    spec.on_fast_confirmation(store)
     output_fast_confirmation_checks(spec, store, test_steps)
 
 
@@ -289,9 +289,7 @@ class FCRTest:
         self.apply_attestations()
 
     def run_fast_confirmation(self):
-        on_slot_start_after_past_attestations_applied_and_append_step(
-            self.spec, self.store, self.test_steps
-        )
+        on_fast_confirmation_and_append_step(self.spec, self.store, self.test_steps)
 
     def next_slot_with_block_and_apply_attestations(
         self,


### PR DESCRIPTION
Allows FCR to be called between the start of a slot and before the attestation deadline, so it’s up to implementation to decide when exactly in this time interval it triggers the algorithm. Specifically, FCR can be called *after* receiving and processing a block if the block is timely.

### Rationale
* Implementations used to call forkchoice function upon receiving a block in a slot or at the attestation deadline. Since FCR depends on the output of the FC function, it makes sense to call FCR *after* the forkchoice to avoid computational inefficiencies.
* FCR incorporates the unrealized justified checkpoint that is received as a part of the block of the last slot of an epoch. This becomes possible because variable update happens *after* a block as opposed to start of the slot as it is done today. This potentially enables FCR to use a fresher UJ checkpoint when only the last block of an epoch contains enough attestations to justify a new checkpoint.

### Security
This change doesn’t affect FCR synchrony assumption as with this change there is still at least 8s for all messages to be disseminated between honest nodes.

### ToDo
* ~~[ ] Change test format. Currently FCR checks are coupled with an `on_tick` event. With this change we will have to introduce `on_fast_confirmation` step to the test format to do FCR checks after the block and adjust tests to yield this step in a correct place~~