### PR TITLE
Fast confirmation: Fix is_confirmed_chain_safe when epoch(GU) < prev_epoch

### DIFF
--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -173,8 +173,8 @@ semantics MUST be preserved.
 
 ##### `get_slot_committee`
 
-*Note:* This function returns the committee for a specific slot and MUST only
-work for current and previous epoch.
+*Note:* This function returns the committee for a specific slot. It MUST support
+committees of epochs starting from `current_epoch - 2`.
 
 ```python
 def get_slot_committee(store: Store, slot: Slot) -> set[ValidatorIndex]:
@@ -434,6 +434,11 @@ def get_adversarial_weight(store: Store, balance_source: BeaconState, block_root
 
 ##### `compute_empty_slot_support_discount`
 
+*Note:* This function MAY compute parent's block support and adversarial weight
+for empty slots belonging to `current_epoch - 2`. It can only happen in
+reconfirmation, in all other cases the earliest possible epoch is
+`current_epoch - 1`.
+
 ```python
 def compute_empty_slot_support_discount(
     store: Store, balance_source: BeaconState, block_root: Root
@@ -552,15 +557,22 @@ def is_confirmed_chain_safe(store: Store, confirmed_root: Root) -> bool:
     if store.current_epoch_observed_justified_checkpoint.epoch + 1 >= current_epoch:
         # Exclude the justified checkpoint block if it is from the previous epoch
         # as then this block will always be canonical in this case.
-        start_root = store.current_epoch_observed_justified_checkpoint.root
+        start_root_exclusive = store.current_epoch_observed_justified_checkpoint.root
     else:
-        # Limit reconfirmation to the checkpoint block
+        # Limit reconfirmation to the first block of the previous epoch
         # as if it's successful, reconfirmation of the ancestors is implied.
-        checkpoint = get_checkpoint_for_block(store, confirmed_root, Epoch(current_epoch - 1))
-        start_root = store.blocks[checkpoint.root].parent_root
+        ancestor_at_previous_epoch_start = get_ancestor(
+            store, confirmed_root, compute_start_slot_at_epoch(Epoch(current_epoch - 1))
+        )
+        if get_block_epoch(store, ancestor_at_previous_epoch_start) + 1 == current_epoch:
+            # The parent of the first block of the previous epoch.
+            start_root_exclusive = store.blocks[ancestor_at_previous_epoch_start].parent_root
+        else:
+            # The last block of the epoch before the previous one.
+            start_root_exclusive = ancestor_at_previous_epoch_start
 
     # Run is_one_confirmed for each block in the confirmed chain with the previous epoch balance source.
-    chain_roots = get_ancestor_roots(store, confirmed_root, start_root)
+    chain_roots = get_ancestor_roots(store, confirmed_root, start_root_exclusive)
     return all(
         is_one_confirmed(store, get_previous_balance_source(store), root) for root in chain_roots
     )

--- a/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
@@ -156,6 +156,10 @@ class FCRTest:
     def head(self):
         return self.spec.get_head(self.store)
 
+    def get_parent(self, root):
+        parent_root = self.store.blocks[root].parent_root
+        return self.store.blocks[parent_root]
+
     def tick(self, slot):
         assert slot > self.current_slot() or slot == self.spec.GENESIS_SLOT
         new_time = slot * self.spec.config.SECONDS_PER_SLOT + self.store.genesis_time

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_reconfirmation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_reconfirmation.py
@@ -1,0 +1,134 @@
+from eth2spec.test.context import (
+    default_activation_threshold,
+    default_balances,
+    MINIMAL,
+    single_phase,
+    spec_test,
+    with_altair_and_later,
+    with_custom_state,
+    with_presets,
+)
+from eth2spec.test.helpers.fast_confirmation import (
+    FCRTest,
+    SystemRun,
+)
+
+"""
+Test is_confirmed_chain_safe
+"""
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_reconfirmation_passes_wtih_empty_slots_prior_first_block(spec, state):
+    """
+    1. Build until last slot of epoch 2 with 100% participation
+    2. Leave last slot of epoch 2 empty
+    3. Leave first slot of epoch 3 empty
+    4. Slash 25% of validators in these two slots
+    5. Run until the start of epoch 3 with blocks and 100% participation.
+       Confirm the first block in epoch 3.
+    6. Check that reconfirmation did not fail
+       In this case reconfirmation will involve committees and equivocated validators
+       from current_epoch - 2.
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+
+    # Run until last slot of epoch 2
+    fcr.run_slots_with_blocks_and_fast_confirmation(3 * S - 1, participation_rate=100)
+
+    confimed_at_last_slot_epoch_2 = store.confirmed_root
+
+    # Leave last slot empty
+    fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
+
+    # Check that reconfirmation passed
+    assert store.confirmed_root == confimed_at_last_slot_epoch_2
+
+    # Epoch 3, Slot 1, empty slot
+    fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
+
+    # Epoch 3, Slot 2, with block
+    fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Check that confirmed block was not advanced
+    assert store.confirmed_root == confimed_at_last_slot_epoch_2
+
+    # Epoch 3, Slot 3
+
+    # Slash participants of (Epoch 2, last slot) and (Epoch 3, first slot)
+    fcr.execute_run(
+        SystemRun(
+            number_of_slots=0,
+            slashing_percentage=25,
+            slash_participants_in_slot_with_offset=-4,
+        )
+    )
+    fcr.execute_run(
+        SystemRun(
+            number_of_slots=0,
+            slashing_percentage=25,
+            slash_participants_in_slot_with_offset=-3,
+        )
+    )
+
+    # Advance with block
+    fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Check confirmed block was not advanced
+    assert store.confirmed_root == confimed_at_last_slot_epoch_2
+
+    # Epoch 3, Slot 4 with block
+    fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Check the head is confirmed
+    assert store.confirmed_root == fcr.head()
+
+    # But if there were no slashings, first block in Epoch 3 couldn't be confirmed at this stage
+    epoch_3_first_block = spec.get_ancestor(store, fcr.head(), 3 * S + 1)
+    balance_source = spec.get_current_balance_source(store)
+
+    support = spec.get_attestation_score(store, epoch_3_first_block, balance_source)
+    proposer_score = spec.compute_proposer_score(balance_source)
+    maximum_support = spec.estimate_committee_weight_between_slots(
+        spec.get_total_active_balance(balance_source),
+        spec.Slot(3 * S - 1),
+        spec.Slot(fcr.current_slot() - 1),
+    )
+
+    # Subtract the slashed balance from the discount
+    # 25% of 2 slots * (len(validators) // SLOTS_PER_EPOCH * effective_balance)
+    slashed_balance = 2 * (len(state.validators) // S * state.validators[0].effective_balance // 4)
+    support_discount = (
+        spec.get_support_discount(store, balance_source, epoch_3_first_block) - slashed_balance
+    )
+
+    adversarial_weight = spec.get_adversarial_weight(store, balance_source, epoch_3_first_block)
+
+    # Check the support is lower than the support threshold
+    assert (
+        2 * support + support_discount < maximum_support + proposer_score + 2 * adversarial_weight
+    )
+
+    # Run till last slot of Epoch 3
+    fcr.execute_run(SystemRun(end_slot=(4 * S - 1), participation_rate=100))
+
+    # Check the head was confirmed
+    assert store.confirmed_root == fcr.head()
+
+    # Run to the start of Epoch 4 with no block
+    fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
+
+    # Check reconfirmation passed
+    assert store.confirmed_root == fcr.head()
+
+    yield from fcr.get_test_artefacts()


### PR DESCRIPTION
Fixes the start block in reconfirmation for the case when `current_epoch_observed_justified_checkpoint` is older than the previous epoch.

Also updates comments on top of `compute_empty_slot_support_discount` and `get_slot_committee` to highlight that they *may* be used to query slots from `current_epoch - 2` in the reconfirmation case.

Credits to @etan-status for finding that issue.

### ToDo
- [x] Write a test covering that case