### PR TITLE
Fast confirmation: Reduce adversary by slashed balance in FFG computation

### DIFF
--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -633,8 +633,8 @@ def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
     """
     current_slot = get_current_slot(store)
     current_epoch = compute_epoch_at_slot(current_slot)
-    state = get_pulled_up_head_state(store)
-    total_active_balance = get_total_active_balance(state)
+    balance_source = get_pulled_up_head_state(store)
+    total_active_balance = get_total_active_balance(balance_source)
 
     # Compute FFG support for the target
     ffg_support_for_checkpoint = get_current_target_score(store)
@@ -650,10 +650,14 @@ def compute_honest_ffg_support_for_current_target(store: Store) -> Gwei:
         remaining_ffg_weight // 100 * (100 - CONFIRMATION_BYZANTINE_THRESHOLD)
     )
 
+    # Compute potential adversarial weight
+    adversarial_weight = compute_adversarial_weight(
+        store, balance_source, compute_start_slot_at_epoch(current_epoch), Slot(current_slot - 1)
+    )
+
     # Compute min honest FFG support
     min_honest_ffg_support = ffg_support_for_checkpoint - min(
-        Gwei(ffg_weight_till_now // 100 * CONFIRMATION_BYZANTINE_THRESHOLD),
-        ffg_support_for_checkpoint,
+        adversarial_weight, ffg_support_for_checkpoint
     )
 
     return Gwei(min_honest_ffg_support + remaining_honest_ffg_weight)

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_current_epoch.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_current_epoch.py
@@ -95,23 +95,8 @@ class CurrentEpochTestBuilder:
         if self.test_spec.second_slot_call:
             # Nothing to do here
             pass
-        elif (
-            self.test_spec.first_block_in_epoch
-            and self.test_spec.one_confirmed_but_no_justification()
-        ):
-            # Slash a fraction of validators each slot
-            # and leave yet enough unslashed to make is_one_confirmed to pass
-            # but will_current_target_be_justified to fail
-            runs.append(
-                SlotRun(
-                    slashing=Slashing(
-                        percentage=45,
-                        committee_slot_or_offset=0,
-                    )
-                )
-            )
         elif self.test_spec.first_block_in_epoch:
-            # Move on to the seconds slot in an epoch
+            # Move on to the second slot in an epoch
             # with participation low enough to prevent confirming a block
             # but still enough to confirm it a slot after if needed
             runs.append(SlotRun(attesting=Attesting(participation_rate=85)))
@@ -119,16 +104,6 @@ class CurrentEpochTestBuilder:
             # Move on to the seconds slot in an epoch
             # and confirm a block
             runs.append(SlotRun())
-
-            if self.test_spec.one_confirmed_but_no_justification():
-                # Slash entire committee that has already confirmed a block,
-                # this will result in will_current_target_be_justified to fail
-                runs.append(
-                    Slashing(
-                        percentage=100,
-                        committee_slot_or_offset=-1,
-                    )
-                )
 
         return runs
 
@@ -149,19 +124,6 @@ class CurrentEpochTestBuilder:
         if self.test_spec.second_slot_call:
             # Nothing to do here
             pass
-        elif (
-            self.test_spec.first_block_in_epoch
-            and self.test_spec.one_confirmed_but_no_justification()
-        ):
-            # Slash a fraction of validators each slot
-            # and leave yet enough unslashed to make is_one_confirmed to pass
-            # but will_current_target_be_justified to fail
-            runs.append(
-                SlotRun(
-                    proposal=Proposal(atts_in_block=False),
-                    slashing=Slashing(percentage=45, committee_slot_or_offset=0),
-                )
-            )
         elif self.test_spec.first_block_in_epoch:
             # Move on to the seconds slot in an epoch
             # without including atts in a block to prevent UJ update
@@ -176,11 +138,10 @@ class CurrentEpochTestBuilder:
             # Create the following block tree:
             #   B
             #  /
-            # A -- C, where:
+            # A -- H, where:
             #
             # UJ[B].epoch == current_epoch - 1
             # UJ[C].epoch == current_epoch - 2
-            # C == head
             #
             # Create A and attest to A
             runs.append(SlotRun(proposal=Proposal(atts_in_block=False)))
@@ -192,18 +153,8 @@ class CurrentEpochTestBuilder:
                     attesting=Attesting(block_slot_or_offset=-1),
                 )
             )
-            # Create C and attest to C, so C becomes the head, confirm A
+            # Create H and attest to it, so H becomes the head, confirm A
             runs.append(SlotRun(proposal=Proposal(parent_root_slot_or_offset=-2)))
-
-            if self.test_spec.one_confirmed_but_no_justification():
-                # Slash entire committee that has confirmed block A,
-                # this will result in will_current_target_be_justified to fail
-                runs.append(
-                    Slashing(
-                        percentage=100,
-                        committee_slot_or_offset=-3,
-                    )
-                )
 
         return runs
 
@@ -259,8 +210,7 @@ class CurrentEpochTestBuilder:
     def create_system_runs(self) -> list[PhaseRun]:
         if self.test_spec.second_slot_call:
             assert self.test_spec.first_block_in_epoch, "Impossible in the second slot of an epoch"
-        if self.test_spec.one_confirmed_but_no_justification():
-            assert not self.test_spec.first_block_in_second_slot(), "The test is hard to build"
+        assert not self.test_spec.one_confirmed_but_no_justification(), "Impossible if beta = 25%"
 
         # Initial run to the second epoch
         runs = [SlotSequence(number_of_slots=self.spec.SLOTS_PER_EPOCH)]
@@ -552,59 +502,3 @@ def test_fcr_current_epoch_17(spec, state):
         is_one_confirmed=False,
     )
     yield from build_and_run_current_epoch_test(spec, state, 17, test_spec)
-
-
-@with_altair_and_later
-@spec_state_test
-@with_presets([MINIMAL], reason="too slow")
-def test_fcr_current_epoch_18(spec, state):
-    test_spec = CurrentEpochTestSpecification(
-        head_uj_fresh=True,
-        second_slot_call=False,
-        first_block_in_epoch=False,
-        target_will_be_justified=False,
-        is_one_confirmed=True,
-    )
-    yield from build_and_run_current_epoch_test(spec, state, 18, test_spec)
-
-
-@with_altair_and_later
-@spec_state_test
-@with_presets([MINIMAL], reason="too slow")
-def test_fcr_current_epoch_19(spec, state):
-    test_spec = CurrentEpochTestSpecification(
-        head_uj_fresh=False,
-        second_slot_call=False,
-        first_block_in_epoch=False,
-        target_will_be_justified=False,
-        is_one_confirmed=True,
-    )
-    yield from build_and_run_current_epoch_test(spec, state, 19, test_spec)
-
-
-@with_altair_and_later
-@spec_state_test
-@with_presets([MINIMAL], reason="too slow")
-def test_fcr_current_epoch_20(spec, state):
-    test_spec = CurrentEpochTestSpecification(
-        head_uj_fresh=True,
-        second_slot_call=False,
-        first_block_in_epoch=True,
-        target_will_be_justified=False,
-        is_one_confirmed=True,
-    )
-    yield from build_and_run_current_epoch_test(spec, state, 20, test_spec)
-
-
-@with_altair_and_later
-@spec_state_test
-@with_presets([MINIMAL], reason="too slow")
-def test_fcr_current_epoch_21(spec, state):
-    test_spec = CurrentEpochTestSpecification(
-        head_uj_fresh=False,
-        second_slot_call=False,
-        first_block_in_epoch=True,
-        target_will_be_justified=False,
-        is_one_confirmed=True,
-    )
-    yield from build_and_run_current_epoch_test(spec, state, 21, test_spec)

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_current_epoch.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_current_epoch.py
@@ -11,11 +11,10 @@ from eth2spec.test.helpers.fast_confirmation import (
     Attesting,
     EmptySlotRun,
     FCRTest,
-    PhaseRun,
     Proposal,
-    Slashing,
     SlotRun,
     SlotSequence,
+    SystemRun,
 )
 
 
@@ -90,81 +89,7 @@ class CurrentEpochTestBuilder:
         self.seed = seed
         self.test_spec = test_spec
 
-    def create_mid_runs_with_fresh_head_uj(self) -> list[PhaseRun]:
-        runs = []
-        if self.test_spec.second_slot_call:
-            # Nothing to do here
-            pass
-        elif self.test_spec.first_block_in_epoch:
-            # Move on to the second slot in an epoch
-            # with participation low enough to prevent confirming a block
-            # but still enough to confirm it a slot after if needed
-            runs.append(SlotRun(attesting=Attesting(participation_rate=85)))
-        else:
-            # Move on to the seconds slot in an epoch
-            # and confirm a block
-            runs.append(SlotRun())
-
-        return runs
-
-    def create_mid_runs_with_stale_head_uj(self) -> list[PhaseRun]:
-        # Run for an epoch with low onchain attestation inclusion
-        # to prevent UJ update while keep fast confirming blocks
-        slots_with_full_inclusion = self.spec.SLOTS_PER_EPOCH * 2 // 3
-        slots_with_zero_inclusion = self.spec.SLOTS_PER_EPOCH - slots_with_full_inclusion
-        runs = [
-            SlotSequence(
-                number_of_slots=slots_with_full_inclusion, proposal=Proposal(atts_in_block=True)
-            ),
-            SlotSequence(
-                number_of_slots=slots_with_zero_inclusion, proposal=Proposal(atts_in_block=False)
-            ),
-        ]
-
-        if self.test_spec.second_slot_call:
-            # Nothing to do here
-            pass
-        elif self.test_spec.first_block_in_epoch:
-            # Move on to the seconds slot in an epoch
-            # without including atts in a block to prevent UJ update
-            # and low participation enough to prevent is_one_confirmed from being True
-            runs.append(
-                SlotRun(
-                    proposal=Proposal(atts_in_block=False),
-                    attesting=Attesting(participation_rate=85),
-                )
-            )
-        else:
-            # Create the following block tree:
-            #   B
-            #  /
-            # A -- H, where:
-            #
-            # UJ[B].epoch == current_epoch - 1
-            # UJ[C].epoch == current_epoch - 2
-            #
-            # Create A and attest to A
-            runs.append(SlotRun(proposal=Proposal(atts_in_block=False)))
-            # Create B but attest to A
-            # B includes attestations from previous epoch enough to update UJ
-            runs.append(
-                SlotRun(
-                    proposal=Proposal(atts_in_block=True),
-                    attesting=Attesting(block_slot_or_offset=-1),
-                )
-            )
-            # Create H and attest to it, so H becomes the head, confirm A
-            runs.append(SlotRun(proposal=Proposal(parent_root_slot_or_offset=-2)))
-
-        return runs
-
-    def create_mid_runs(self) -> list[PhaseRun]:
-        if self.test_spec.head_uj_fresh:
-            return self.create_mid_runs_with_fresh_head_uj()
-        else:
-            return self.create_mid_runs_with_stale_head_uj()
-
-    def get_final_run_participation_rate(self) -> int:
+    def get_target_participation(self) -> int:
         if self.test_spec.is_one_confirmed:
             # Full participation
             return 100
@@ -177,51 +102,138 @@ class CurrentEpochTestBuilder:
             # nor to justify a target
             return 0
 
-    def create_final_run(self) -> PhaseRun:
-        if self.test_spec.first_block_at_mid_epoch():
-            if self.test_spec.one_confirmed_but_no_justification():
-                # Slash a fraction of validators each slot
-                # and leave yet enough unslashed to make is_one_confirmed to pass
-                # but will_current_target_be_justified to fail
-                slashing_percentage = 45
-            else:
-                slashing_percentage = 0
-
-            # Do not propose when the first block of the epoch
-            # should be confirmed mid epoch
-            return EmptySlotRun(
-                attesting=Attesting(participation_rate=self.get_final_run_participation_rate()),
-                slashing=Slashing(
-                    percentage=slashing_percentage,
-                    committee_slot_or_offset=0,
-                ),
-                # Final run without fast confirmation as it will be triggered by the test execution
-                advance_slot=AdvanceSlot(with_fast_confirmation=False),
-            )
+    def initial_run_and_end_epoch(self) -> (list[SystemRun], int):
+        if self.test_spec.head_uj_fresh:
+            # Run to the second epoch
+            run = [SlotSequence(number_of_slots=self.spec.SLOTS_PER_EPOCH)]
+            return run, 2
         else:
-            return SlotRun(
+            # Run to the second epoch and then
+            # run for an epoch with low onchain attestation inclusion
+            # to prevent UJ update while keep fast confirming blocks
+            run = [
+                # Run to the second epoch
+                SlotSequence(number_of_slots=self.spec.SLOTS_PER_EPOCH),
+                # Slots with full inclusion at the beginning
+                SlotSequence(
+                    number_of_slots=self.spec.SLOTS_PER_EPOCH * 2 // 3,
+                    proposal=Proposal(atts_in_block=True),
+                ),
+                # Up to the next epoch start with zero enclusion
+                SlotSequence(
+                    end_slot=2 * self.spec.SLOTS_PER_EPOCH, proposal=Proposal(atts_in_block=False)
+                ),
+            ]
+            return run, 3
+
+    def first_block_in_second_slot_run(self) -> list[SystemRun]:
+        return [
+            SlotRun(
                 # Prevent UJ update unless UJ must be fresh
                 proposal=Proposal(atts_in_block=self.test_spec.head_uj_fresh),
-                attesting=Attesting(participation_rate=self.get_final_run_participation_rate()),
-                # Final run without fast confirmation as it will be triggered by the test execution
+                attesting=Attesting(participation_rate=self.get_target_participation()),
                 advance_slot=AdvanceSlot(with_fast_confirmation=False),
             )
+        ]
 
-    def create_system_runs(self) -> list[PhaseRun]:
-        if self.test_spec.second_slot_call:
-            assert self.test_spec.first_block_in_epoch, "Impossible in the second slot of an epoch"
-        assert not self.test_spec.one_confirmed_but_no_justification(), "Impossible if beta = 25%"
+    def no_justification_final_run(self, end_epoch) -> list[SystemRun]:
+        # Sequence of empty slots with participation enough to one confirm
+        # but not enough to justify
+        return [
+            SlotSequence(
+                end_slot=end_epoch * self.spec.SLOTS_PER_EPOCH - 2,
+                proposal=Proposal(enabled=False),
+                attesting=Attesting(participation_rate=75),
+            ),
+            # Attest and advance slot with no fast confirmation
+            # fast confirmation will be triggered by the test runner
+            # later into the process
+            EmptySlotRun(
+                attesting=Attesting(participation_rate=self.get_target_participation()),
+                advance_slot=AdvanceSlot(with_fast_confirmation=False),
+            ),
+        ]
 
-        # Initial run to the second epoch
-        runs = [SlotSequence(number_of_slots=self.spec.SLOTS_PER_EPOCH)]
+    def regular_final_run(self) -> list[SystemRun]:
+        # Attest and advance slot with no fast confirmation
+        # fast confirmation will be triggered by the test runner
+        # later into the process
+        return [
+            Attesting(participation_rate=self.get_target_participation()),
+            AdvanceSlot(with_fast_confirmation=False),
+        ]
 
-        # Mid runs depending on the test spec
-        runs.extend(self.create_mid_runs())
+    def confirm_at_mid_epoch_final_run(self, end_epoch) -> list[SystemRun]:
+        if self.test_spec.one_confirmed_but_no_justification():
+            return self.no_justification_final_run(end_epoch)
+        else:
+            return self.regular_final_run()
 
-        # Final run
-        runs.append(self.create_final_run())
+    def first_block_at_mid_epoch_run(self, end_epoch) -> list[SystemRun]:
+        # Move on to the second slot in an epoch
+        # with proposal and participation low enough to prevent confirming a proposed block
+        # but still enough to confirm it a slot after if needed
+        run = [
+            SlotRun(
+                proposal=Proposal(atts_in_block=self.test_spec.head_uj_fresh),
+                attesting=Attesting(participation_rate=85),
+            ),
+        ]
 
-        return runs
+        # Finalize
+        run.extend(self.confirm_at_mid_epoch_final_run(end_epoch))
+
+        return run
+
+    def second_block_at_mid_epoch_run(self, end_epoch) -> list[SystemRun]:
+        if self.test_spec.head_uj_fresh:
+            # Move on to the seconds slot in an epoch with confirmation and child block proposal,
+            # then attempt to confirm a child block
+            run = [SlotRun(), Proposal()]
+        else:
+            # Create the following block tree:
+            #   B
+            #  /
+            # A -- H, where:
+            #
+            # UJ[B].epoch == current_epoch - 1
+            # UJ[H].epoch == current_epoch - 2
+            run = [
+                # Create A and attest to A
+                SlotRun(proposal=Proposal(atts_in_block=False)),
+                # Create B but attest to A
+                # B includes attestations from previous epoch enough to update UJ
+                SlotRun(
+                    proposal=Proposal(atts_in_block=True),
+                    attesting=Attesting(block_slot_or_offset=-1),
+                ),
+                # Create H and attest to it, so H becomes the head, confirm A
+                SlotRun(proposal=Proposal(parent_root_slot_or_offset=-2)),
+                # Prevent UJ update unless UJ must be fresh
+                Proposal(atts_in_block=False),
+            ]
+
+        # Finalize
+        run.extend(self.confirm_at_mid_epoch_final_run(end_epoch))
+
+        return run
+
+    def create_system_runs(self) -> list[SystemRun]:
+        test_spec = self.test_spec
+        if test_spec.second_slot_call:
+            assert test_spec.first_block_in_epoch, "Impossible in the second slot of an epoch"
+        if test_spec.one_confirmed_but_no_justification():
+            assert not test_spec.first_block_in_second_slot(), "Impossible with beta = 25%"
+
+        # Initial run
+        init, end_epoch = self.initial_run_and_end_epoch()
+
+        if test_spec.first_block_in_second_slot():
+            return init + self.first_block_in_second_slot_run()
+        elif self.test_spec.first_block_at_mid_epoch():
+            return init + self.first_block_at_mid_epoch_run(end_epoch)
+        else:
+            return init + self.second_block_at_mid_epoch_run(end_epoch)
 
     def build(self):
         fcr_test = FCRTest(self.spec, self.seed)
@@ -502,3 +514,59 @@ def test_fcr_current_epoch_17(spec, state):
         is_one_confirmed=False,
     )
     yield from build_and_run_current_epoch_test(spec, state, 17, test_spec)
+
+
+@with_altair_and_later
+@spec_state_test
+@with_presets([MINIMAL], reason="too slow")
+def test_fcr_current_epoch_18(spec, state):
+    test_spec = CurrentEpochTestSpecification(
+        head_uj_fresh=True,
+        second_slot_call=False,
+        first_block_in_epoch=False,
+        target_will_be_justified=False,
+        is_one_confirmed=True,
+    )
+    yield from build_and_run_current_epoch_test(spec, state, 18, test_spec)
+
+
+@with_altair_and_later
+@spec_state_test
+@with_presets([MINIMAL], reason="too slow")
+def test_fcr_current_epoch_19(spec, state):
+    test_spec = CurrentEpochTestSpecification(
+        head_uj_fresh=False,
+        second_slot_call=False,
+        first_block_in_epoch=False,
+        target_will_be_justified=False,
+        is_one_confirmed=True,
+    )
+    yield from build_and_run_current_epoch_test(spec, state, 19, test_spec)
+
+
+@with_altair_and_later
+@spec_state_test
+@with_presets([MINIMAL], reason="too slow")
+def test_fcr_current_epoch_20(spec, state):
+    test_spec = CurrentEpochTestSpecification(
+        head_uj_fresh=True,
+        second_slot_call=False,
+        first_block_in_epoch=True,
+        target_will_be_justified=False,
+        is_one_confirmed=True,
+    )
+    yield from build_and_run_current_epoch_test(spec, state, 20, test_spec)
+
+
+@with_altair_and_later
+@spec_state_test
+@with_presets([MINIMAL], reason="too slow")
+def test_fcr_current_epoch_21(spec, state):
+    test_spec = CurrentEpochTestSpecification(
+        head_uj_fresh=False,
+        second_slot_call=False,
+        first_block_in_epoch=True,
+        target_will_be_justified=False,
+        is_one_confirmed=True,
+    )
+    yield from build_and_run_current_epoch_test(spec, state, 21, test_spec)


### PR DESCRIPTION
### Description
Subtracts already slashed validators from an adversarial fraction in computation of the FFG support of the target checkpoint in `compute_honest_ffg_support_for_current_target`:

* Makes it in the same way as `is_one_confirmed` does
* Should increase FCR liveness in the mass slashing case by reducing the threshold required for `will_current_target_be_justified` to pass
* Safe as under our assumption honest validators are never [mass] slashed

### ToDo
* [x] Fix tests