### PR TITLE
Fast confirmation: Move LMD-GHOST threshold computation to a separate function

### DIFF
--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -30,6 +30,7 @@
       - [`get_adversarial_weight`](#get_adversarial_weight)
       - [`compute_empty_slot_support_discount`](#compute_empty_slot_support_discount)
       - [`get_support_discount`](#get_support_discount)
+      - [`compute_safety_threshold`](#compute_safety_threshold)
       - [`is_one_confirmed`](#is_one_confirmed)
       - [`is_confirmed_chain_safe`](#is_confirmed_chain_safe)
     - [FFG helpers](#ffg-helpers)
@@ -483,6 +484,28 @@ def get_support_discount(store: Store, balance_source: BeaconState, block_root: 
     return compute_empty_slot_support_discount(store, balance_source, block_root)
 ```
 
+##### `compute_safety_threshold`
+
+```python
+def compute_safety_threshold(store: Store, block_root: Root, balance_source: BeaconState) -> bool:
+    """
+    Compute the LMD_GHOST safety threshold for ``block_root``.
+    """
+    current_slot = get_current_slot(store)
+    block = store.blocks[block_root]
+    parent_block = store.blocks[block.parent_root]
+
+    proposer_score = compute_proposer_score(balance_source)
+    total_active_balance = get_total_active_balance(balance_source)
+    maximum_support = estimate_committee_weight_between_slots(
+        total_active_balance, Slot(parent_block.slot + 1), Slot(current_slot - 1)
+    )
+    support_discount = get_support_discount(store, balance_source, block_root)
+    adversarial_weight = get_adversarial_weight(store, balance_source, block_root)
+
+    return (maximum_support + proposer_score - support_discount) // 2 + adversarial_weight
+```
+
 ##### `is_one_confirmed`
 
 *Notes:*
@@ -506,25 +529,10 @@ def is_one_confirmed(store: Store, balance_source: BeaconState, block_root: Root
     """
     Return ``True`` if and only if the block is LMD-GHOST safe.
     """
-    current_slot = get_current_slot(store)
-    block = store.blocks[block_root]
-    parent_block = store.blocks[block.parent_root]
-
     support = get_attestation_score(store, block_root, balance_source)
-    proposer_score = compute_proposer_score(balance_source)
-    total_active_balance = get_total_active_balance(balance_source)
-    maximum_support = estimate_committee_weight_between_slots(
-        total_active_balance, Slot(parent_block.slot + 1), Slot(current_slot - 1)
-    )
-    support_discount = get_support_discount(store, balance_source, block_root)
-    adversarial_weight = get_adversarial_weight(store, balance_source, block_root)
+    safety_threshold = compute_safety_threshold(store, block_root, balance_source)
 
-    # Returns whether the following condition is true using only integer arithmetic:
-    # support / maximum_support >
-    #   0.5 * (1 + (proposer_score - support_discount) / maximum_support) + adversarial_weight / maximum_support
-    return (
-        2 * support + support_discount > maximum_support + proposer_score + 2 * adversarial_weight
-    )
+    return support > safety_threshold
 ```
 
 ##### `is_confirmed_chain_safe`

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -503,6 +503,7 @@ def compute_safety_threshold(store: Store, block_root: Root, balance_source: Bea
     support_discount = get_support_discount(store, balance_source, block_root)
     adversarial_weight = get_adversarial_weight(store, balance_source, block_root)
 
+    # The subtraction is safe as maximum_support is always greater than support_discount
     return (maximum_support + proposer_score - support_discount) // 2 + adversarial_weight
 ```
 

--- a/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
@@ -365,32 +365,12 @@ class FCRTest:
         return attester_slashing
 
     def compute_score_and_threshold(self, block_root) -> (int, int):
-        """
-        Computes one confirmed score and threshold.
-        """
-        spec = self.spec
-        store = self.store
-
-        current_slot = spec.get_current_slot(store)
-        block = store.blocks[block_root]
-        parent_block = store.blocks[block.parent_root]
-        balance_source = spec.get_current_balance_source(store)
-
-        score = spec.get_attestation_score(store, block_root, balance_source)
-        proposer_score = spec.compute_proposer_score(balance_source)
-        total_active_balance = spec.get_total_active_balance(balance_source)
-        maximum_support = spec.estimate_committee_weight_between_slots(
-            total_active_balance, spec.Slot(parent_block.slot + 1), spec.Slot(current_slot - 1)
+        balance_source = self.spec.get_current_balance_source(self.store)
+        score = self.spec.get_attestation_score(self.store, block_root, balance_source)
+        safety_threshold = self.spec.compute_safety_threshold(
+            self.store, block_root, balance_source
         )
-        support_discount = spec.get_support_discount(store, balance_source, block_root)
-        adversarial_weight = spec.get_adversarial_weight(store, balance_source, block_root)
-
-        # 0.5 * (maximum_support + proposer_score - support_discount) + adversarial_weight
-        threshold = (int(maximum_support) + int(proposer_score) - int(support_discount)) / 2 + int(
-            adversarial_weight
-        )
-
-        return int(score), int(threshold)
+        return int(score), int(safety_threshold)
 
     def get_slot_root_info(self, block_root):
         if block_root == self.spec.Root():

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_reconfirmation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_reconfirmation.py
@@ -80,28 +80,16 @@ def test_reconfirmation_passes_wtih_empty_slots_prior_first_block(spec, state):
     # But if there were no slashings, first block in Epoch 3 couldn't be confirmed at this stage
     epoch_3_first_block = spec.get_ancestor(store, fcr.head(), 3 * S + 1)
     balance_source = spec.get_current_balance_source(store)
-
     support = spec.get_attestation_score(store, epoch_3_first_block, balance_source)
-    proposer_score = spec.compute_proposer_score(balance_source)
-    maximum_support = spec.estimate_committee_weight_between_slots(
-        spec.get_total_active_balance(balance_source),
-        spec.Slot(3 * S - 1),
-        spec.Slot(fcr.current_slot() - 1),
-    )
+    safety_threshold = spec.compute_safety_threshold(store, epoch_3_first_block, balance_source)
 
-    # Subtract the slashed balance from the discount
+    # Compute slashed balance
     # 25% of 2 slots * (len(validators) // SLOTS_PER_EPOCH * effective_balance)
     slashed_balance = 2 * (len(state.validators) // S * state.validators[0].effective_balance // 4)
-    support_discount = (
-        spec.get_support_discount(store, balance_source, epoch_3_first_block) - slashed_balance
-    )
 
-    adversarial_weight = spec.get_adversarial_weight(store, balance_source, epoch_3_first_block)
-
-    # Check the support is lower than the support threshold
-    assert (
-        2 * support + support_discount < maximum_support + proposer_score + 2 * adversarial_weight
-    )
+    # Add a half of slashed balance back to the safety threshold
+    # and check the support would be lower than the threshold
+    assert support < safety_threshold + slashed_balance // 2
 
     # Run till last slot of Epoch 3
     SlotSequence(end_slot=(4 * S - 1), attesting=Attesting(participation_rate=100)).execute(fcr)


### PR DESCRIPTION
Extracts LMD-GHOST threshold from `is_one_confirmed` and moves it into a separate function.

* Does not change the logic
* Makes `is_one_confirmed` cleaner
* Allows to use `compute_safety_threshold` in tests which is handy
