### PR TITLE
No restart if justified block is old

### DIFF
--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -926,16 +926,25 @@ def get_latest_confirmed(store: Store) -> Root:
 
     # Restart the confirmation chain if each of the following conditions are true:
     # 1) it is the start of the current epoch,
-    # 2) epoch of store.current_epoch_observed_justified_checkpoint equals to the previous epoch,
+    # 2) epoch of store.current_epoch_observed_justified_checkpoint.root equals to the previous epoch,
     # 3) store.current_epoch_observed_justified_checkpoint equals to unrealized justification of the head,
     # 4) confirmed block is older than the block of store.current_epoch_observed_justified_checkpoint.
+    observed_justified_block_slot = get_block_slot(
+        store, store.current_epoch_observed_justified_checkpoint.root
+    )
+    is_epoch_start = is_start_slot_at_epoch(get_current_slot(store))
+    is_observed_justified_block_epoch_ok = (
+        compute_epoch_at_slot(observed_justified_block_slot) + 1 == current_epoch
+    )
+    is_head_unrealized_justified_ok = (
+        store.unrealized_justifications[head] == store.current_epoch_observed_justified_checkpoint
+    )
+    is_confirmed_block_stale = get_block_slot(store, confirmed_root) < observed_justified_block_slot
     if (
-        is_start_slot_at_epoch(get_current_slot(store))
-        and store.current_epoch_observed_justified_checkpoint.epoch + 1 == current_epoch
-        and store.current_epoch_observed_justified_checkpoint
-        == store.unrealized_justifications[head]
-        and get_block_slot(store, confirmed_root)
-        < get_block_slot(store, store.current_epoch_observed_justified_checkpoint.root)
+        is_epoch_start
+        and is_observed_justified_block_epoch_ok
+        and is_head_unrealized_justified_ok
+        and is_confirmed_block_stale
     ):
         confirmed_root = store.current_epoch_observed_justified_checkpoint.root
 

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -929,15 +929,15 @@ def get_latest_confirmed(store: Store) -> Root:
     # 2) epoch of store.current_epoch_observed_justified_checkpoint.root equals to the previous epoch,
     # 3) store.current_epoch_observed_justified_checkpoint equals to unrealized justification of the head,
     # 4) confirmed block is older than the block of store.current_epoch_observed_justified_checkpoint.
+    is_epoch_start = is_start_slot_at_epoch(get_current_slot(store))
     observed_justified_block_slot = get_block_slot(
         store, store.current_epoch_observed_justified_checkpoint.root
     )
-    is_epoch_start = is_start_slot_at_epoch(get_current_slot(store))
     is_observed_justified_block_epoch_ok = (
         compute_epoch_at_slot(observed_justified_block_slot) + 1 == current_epoch
     )
     is_head_unrealized_justified_ok = (
-        store.unrealized_justifications[head] == store.current_epoch_observed_justified_checkpoint
+        store.current_epoch_observed_justified_checkpoint == store.unrealized_justifications[head]
     )
     is_confirmed_block_stale = get_block_slot(store, confirmed_root) < observed_justified_block_slot
     if (

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
@@ -334,3 +334,95 @@ def test_fcr_no_restart_to_gu_because_gu_too_old(spec, state):
     )
 
     yield from fcr.get_test_artefacts()
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="too slow")
+@with_custom_state(
+    balances_fn=(lambda spec: default_balances(spec, num_validators=64)),
+    threshold_fn=default_activation_threshold,
+)
+@spec_test
+@single_phase
+def test_fcr_no_restart_when_gu_block_is_epoch_older(spec, state):
+    """
+    DEBUG: Verify restart-to-GU path is actually triggered.
+    """
+    fcr = FCRTest(spec, seed=1)
+    store = fcr.initialize(state)
+
+    S = spec.SLOTS_PER_EPOCH
+    epoch4_start = 4 * S
+    epoch5_start = 5 * S
+
+    # Epochs 0-3: Full participation (up to first slot of epoch 4)
+    while fcr.current_slot() < epoch4_start:
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    # Epoch 4. First Slot empty
+    fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
+
+    # Epoch 4. Rest slots with full participation
+    while fcr.current_slot() < epoch5_start - 1:
+        fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
+
+    assert fcr.current_slot() == epoch5_start - 1
+    assert store.finalized_checkpoint.epoch >= spec.Epoch(2)
+
+    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
+        f"GU snapshot should be epoch 4, got {store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
+    )
+
+    confirmed_before = store.confirmed_root
+    finalized_root = store.finalized_checkpoint.root
+    assert confirmed_before != finalized_root, (
+        "Precondition: confirmed should be ahead of finalized"
+    )
+
+    # Last slot of epoch 4: build block, attest
+    block_root = fcr.add_and_apply_block(parent_root=fcr.head())
+    fcr.attest(block_root=block_root, slot=fcr.current_slot(), participation_rate=100)
+
+    # Late slashing arrives during last slot of epoch 4
+    fcr.apply_attester_slashing(slashing_percentage=50, slot=fcr.current_slot())
+
+    # Cross into epoch 5
+    fcr.next_slot()
+
+    # Before FCR: check reconfirmation status
+    debug_print(
+        f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(store, confirmed_before)}"
+    )
+    debug_print(f"confirmed_before slot: {store.blocks[confirmed_before].slot}")
+    debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
+    debug_print(f"equivocating_indices: {len(store.equivocating_indices)}")
+
+    fcr.run_fast_confirmation()
+
+    assert fcr.current_slot() == epoch5_start
+    assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
+
+    gu = store.current_epoch_observed_justified_checkpoint
+    current_epoch = spec.get_current_store_epoch(store)
+    finalized_root = store.finalized_checkpoint.root
+
+    debug_print("\nAfter FCR:")
+    debug_print(f"gu.epoch: {gu.epoch}, current_epoch: {current_epoch}")
+    debug_print(f"confirmed_root slot: {store.blocks[store.confirmed_root].slot}")
+    debug_print(f"gu.root slot: {store.blocks[gu.root].slot}")
+    debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
+    debug_print(f"confirmed == gu.root: {store.confirmed_root == gu.root}")
+    debug_print(f"confirmed == finalized: {store.confirmed_root == finalized_root}")
+    debug_print(f"confirmed == confirmed_before: {store.confirmed_root == confirmed_before}")
+
+    assert gu.epoch + 1 == current_epoch, (
+        f"GU should be fresh after rotation: {gu.epoch} + 1 != {current_epoch}"
+    )
+
+    assert spec.get_block_epoch(store, gu.root) + 1 < current_epoch, (
+        f"GU block must be old after rotation: {spec.get_block_epoch(store, gu.root)} + 1 == {current_epoch}"
+    )
+
+    assert store.confirmed_root == finalized_root, "MUST stay at finalized"
+
+    yield from fcr.get_test_artefacts()


### PR DESCRIPTION
### Description

Check an epoch of `current_epoch_observed_justified_checkpoint.root` instead of `current_epoch_observed_justified_checkpoint.epoch` in the restart conditions of the algorithm.

If a checkpoint is from the previous epoch but the block is from an epoch older than the previous one (the first slot of the previous epoch is empty) then the following would happen at the restart:
* `store.confirmed_root = store.current_epoch_observed_justified_checkpoint.root`
* No call of the `find_latest_confirmed_descendant` happens because `get_block_epoch(store, confirmed_root) + 1 < current_epoch`
* Revert to finality at the next slot because `get_block_epoch(store, confirmed_root) + 1 < current_epoch`

The corresponding test is a part of the PR. There is also a slight refactor of the restart conditions to aid readability.