### PR TITLE
Use ceil div in adjust_committee_weight_estimate_to_ensure_safety

### DIFF
--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -326,7 +326,8 @@ def adjust_committee_weight_estimate_to_ensure_safety(estimate: Gwei) -> Gwei:
     """
     Return adjusted ``estimate`` of the weight of a committee for a sequence of slots not covering a full epoch.
     """
-    return Gwei(estimate // 1000 * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR))
+    ceil = (estimate + 999) // 1000
+    return Gwei(ceil * (1000 + COMMITTEE_WEIGHT_ESTIMATION_ADJUSTMENT_FACTOR))
 ```
 
 ##### `estimate_committee_weight_between_slots`


### PR DESCRIPTION
Addresses https://github.com/ethereum/consensus-specs/pull/4747#discussion_r2770249914 by switching the computation from floor to ceil.

cc @terencechain @saltiniroberto