### PR TITLE
Make FCR use a separate store

### DIFF
--- a/fork_choice/safe-block.md
+++ b/fork_choice/safe-block.md
@@ -3,6 +3,7 @@
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
 - [Introduction](#introduction)
+- [`get_fast_confirmation_store`](#get_fast_confirmation_store)
 - [`get_safe_beacon_block_root`](#get_safe_beacon_block_root)
 - [`get_safe_execution_block_hash`](#get_safe_execution_block_hash)
 
@@ -16,20 +17,30 @@ head of canonical chain which makes it valuable to expose a safe block to users.
 
 This section describes an algorithm to find a safe block.
 
+## `get_fast_confirmation_store`
+
+*Note*: Abstract function that returns an instance of `FastConfirmationStore`
+defined in [Fast Confirmation](../specs/phase0/fast-confirmation.md).
+
+```python
+def get_fast_confirmation_store() -> FastConfirmationStore:
+    pass
+```
+
 ## `get_safe_beacon_block_root`
 
 ```python
-def get_safe_beacon_block_root(fcr_store: FastConfirmationStore) -> Root:
+def get_safe_beacon_block_root(store: Store) -> Root:
     # Use the most recent confirmed_root determined by the FCR algorithm
-    return fcr_store.confirmed_root
+    return get_fast_confirmation_store().confirmed_root
 ```
 
 ## `get_safe_execution_block_hash`
 
 ```python
-def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
-    safe_block_root = get_safe_beacon_block_root(fcr_store)
-    safe_block = fcr_store.store.blocks[safe_block_root]
+def get_safe_execution_block_hash(store: Store) -> Hash32:
+    safe_block_root = get_safe_beacon_block_root(store)
+    safe_block = store.blocks[safe_block_root]
 
     # Return Hash32() if no payload is yet justified
     if compute_epoch_at_slot(safe_block.slot) >= BELLATRIX_FORK_EPOCH:

--- a/fork_choice/safe-block.md
+++ b/fork_choice/safe-block.md
@@ -19,17 +19,17 @@ This section describes an algorithm to find a safe block.
 ## `get_safe_beacon_block_root`
 
 ```python
-def get_safe_beacon_block_root(store: Store) -> Root:
+def get_safe_beacon_block_root(fcr_store: FastConfirmationStore) -> Root:
     # Use the most recent confirmed_root determined by the FCR algorithm
-    return store.confirmed_root
+    return fcr_store.confirmed_root
 ```
 
 ## `get_safe_execution_block_hash`
 
 ```python
-def get_safe_execution_block_hash(store: Store) -> Hash32:
-    safe_block_root = get_safe_beacon_block_root(store)
-    safe_block = store.blocks[safe_block_root]
+def get_safe_execution_block_hash(fcr_store: FastConfirmationStore) -> Hash32:
+    safe_block_root = get_safe_beacon_block_root(fcr_store)
+    safe_block = fcr_store.store.blocks[safe_block_root]
 
     # Return Hash32() if no payload is yet justified
     if compute_epoch_at_slot(safe_block.slot) >= BELLATRIX_FORK_EPOCH:

--- a/specs/_features/eip7805/fork-choice.md
+++ b/specs/_features/eip7805/fork-choice.md
@@ -119,12 +119,6 @@ class Store(object):
     unrealized_justified_checkpoint: Checkpoint
     unrealized_finalized_checkpoint: Checkpoint
     proposer_boost_root: Root
-    confirmed_root: Root
-    previous_epoch_observed_justified_checkpoint: Checkpoint
-    current_epoch_observed_justified_checkpoint: Checkpoint
-    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
-    previous_slot_head: Root
-    current_slot_head: Root
     equivocating_indices: Set[ValidatorIndex]
     blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
     block_states: Dict[Root, BeaconState] = field(default_factory=dict)
@@ -154,12 +148,6 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         unrealized_justified_checkpoint=justified_checkpoint,
         unrealized_finalized_checkpoint=finalized_checkpoint,
         proposer_boost_root=proposer_boost_root,
-        confirmed_root=anchor_root,
-        previous_epoch_observed_justified_checkpoint=justified_checkpoint,
-        current_epoch_observed_justified_checkpoint=justified_checkpoint,
-        previous_epoch_greatest_unrealized_checkpoint=justified_checkpoint,
-        previous_slot_head=anchor_root,
-        current_slot_head=anchor_root,
         equivocating_indices=set(),
         blocks={anchor_root: copy(anchor_block)},
         block_states={anchor_root: copy(anchor_state)},

--- a/specs/gloas/fork-choice.md
+++ b/specs/gloas/fork-choice.md
@@ -131,12 +131,6 @@ class Store(object):
     unrealized_justified_checkpoint: Checkpoint
     unrealized_finalized_checkpoint: Checkpoint
     proposer_boost_root: Root
-    confirmed_root: Root
-    previous_epoch_observed_justified_checkpoint: Checkpoint
-    current_epoch_observed_justified_checkpoint: Checkpoint
-    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
-    previous_slot_head: Root
-    current_slot_head: Root
     equivocating_indices: Set[ValidatorIndex]
     blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
     block_states: Dict[Root, BeaconState] = field(default_factory=dict)
@@ -170,12 +164,6 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         unrealized_justified_checkpoint=justified_checkpoint,
         unrealized_finalized_checkpoint=finalized_checkpoint,
         proposer_boost_root=proposer_boost_root,
-        confirmed_root=anchor_root,
-        previous_epoch_observed_justified_checkpoint=justified_checkpoint,
-        current_epoch_observed_justified_checkpoint=justified_checkpoint,
-        previous_epoch_greatest_unrealized_checkpoint=justified_checkpoint,
-        previous_slot_head=anchor_root,
-        current_slot_head=anchor_root,
         equivocating_indices=set(),
         blocks={anchor_root: copy(anchor_block)},
         block_states={anchor_root: copy(anchor_state)},

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -86,7 +86,7 @@ blocks can be reorged without any adversarial behavior and without slashing.
 The `FastConfirmationStore` is responsible for tracking information required for
 the fast confirmation rule . The fields being tracked are described below:
 
-- `store`: fork choice `Store` instance, added for convenience.
+- `store`: read-only instance of the fork choice `Store`, added for convenience.
 - `confirmed_root`: root of the most recent confirmed block.
 - `previous_epoch_observed_justified_checkpoint`: a justified checkpoint that
   has been observed by all honest nodes at the beginning of the previous epoch
@@ -118,10 +118,9 @@ Initialization of the fast confirmation store should happen at the same time as
 initialization of the fork choice store and use the same trusted checkpoint.
 
 *Note*: This function conservatively uses `store.finalized_checkpoint` for all
-fast confirmation variables. Auxiliary variables will be updated at no later
-than the next epoch boundary which allows for a start with a fresher confirmed
-block if conditions are met, before that finalized block will be returned as the
-confirmed one.
+fast confirmation variables. Confirmed block will be advanced at any future
+epoch boundary when the starting conditions are met, before that the finalized
+block will be returned as the confirmed one.
 
 ```python
 def get_fast_confirmation_store(store: Store) -> FastConfirmationStore:

--- a/specs/phase0/fast-confirmation.md
+++ b/specs/phase0/fast-confirmation.md
@@ -7,6 +7,8 @@
   - [Constants](#constants)
   - [Configuration](#configuration)
   - [Helpers](#helpers)
+    - [`FastConfirmationStore`](#fastconfirmationstore)
+    - [`get_fast_confirmation_store`](#get_fast_confirmation_store)
     - [Misc helper functions](#misc-helper-functions)
       - [`get_block_slot`](#get_block_slot)
       - [`get_block_epoch`](#get_block_epoch)
@@ -78,6 +80,61 @@ blocks can be reorged without any adversarial behavior and without slashing.
 | `CONFIRMATION_BYZANTINE_THRESHOLD` | `uint64(25)` | `uint64(25)` | Assumed maximum percentage of Byzantine validators among the validator set. |
 
 ### Helpers
+
+#### `FastConfirmationStore`
+
+The `FastConfirmationStore` is responsible for tracking information required for
+the fast confirmation rule . The fields being tracked are described below:
+
+- `store`: fork choice `Store` instance, added for convenience.
+- `confirmed_root`: root of the most recent confirmed block.
+- `previous_epoch_observed_justified_checkpoint`: a justified checkpoint that
+  has been observed by all honest nodes at the beginning of the previous epoch
+  assuming synchrony.
+- `current_epoch_observed_justified_checkpoint`: a justified checkpoint that has
+  been observed by all honest nodes at the beginning of the current epoch
+  assuming synchrony.
+- `previous_epoch_greatest_unrealized_checkpoint`: a greatest unrealized
+  justified checkpoint at the start of the last slot of the previous epoch
+  according to a local view.
+- `previous_slot_head`: the head at the start of the previous slot.
+- `current_slot_head`: the head at the start of the current slot.
+
+```python
+@dataclass
+class FastConfirmationStore(object):
+    store: Store
+    confirmed_root: Root
+    previous_epoch_observed_justified_checkpoint: Checkpoint
+    current_epoch_observed_justified_checkpoint: Checkpoint
+    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
+    previous_slot_head: Root
+    current_slot_head: Root
+```
+
+#### `get_fast_confirmation_store`
+
+Initialization of the fast confirmation store should happen at the same time as
+initialization of the fork choice store and use the same trusted checkpoint.
+
+*Note*: This function conservatively uses `store.finalized_checkpoint` for all
+fast confirmation variables. Auxiliary variables will be updated at no later
+than the next epoch boundary which allows for a start with a fresher confirmed
+block if conditions are met, before that finalized block will be returned as the
+confirmed one.
+
+```python
+def get_fast_confirmation_store(store: Store) -> FastConfirmationStore:
+    return FastConfirmationStore(
+        store=store,
+        confirmed_root=store.finalized_checkpoint.root,
+        previous_epoch_observed_justified_checkpoint=store.finalized_checkpoint,
+        current_epoch_observed_justified_checkpoint=store.finalized_checkpoint,
+        previous_epoch_greatest_unrealized_checkpoint=store.finalized_checkpoint,
+        previous_slot_head=store.finalized_checkpoint.root,
+        current_slot_head=store.finalized_checkpoint.root,
+    )
+```
 
 #### Misc helper functions
 
@@ -219,15 +276,17 @@ reconfirmation and before the logic to confirm new blocks is called. In this
 case implementations will need to keep only a single balance source around.
 
 ```python
-def get_previous_balance_source(store: Store) -> BeaconState:
-    return store.checkpoint_states[store.previous_epoch_observed_justified_checkpoint]
+def get_previous_balance_source(fcr_store: FastConfirmationStore) -> BeaconState:
+    store = fcr_store.store
+    return store.checkpoint_states[fcr_store.previous_epoch_observed_justified_checkpoint]
 ```
 
 ##### `get_current_balance_source`
 
 ```python
-def get_current_balance_source(store: Store) -> BeaconState:
-    return store.checkpoint_states[store.current_epoch_observed_justified_checkpoint]
+def get_current_balance_source(fcr_store: FastConfirmationStore) -> BeaconState:
+    store = fcr_store.store
+    return store.checkpoint_states[fcr_store.current_epoch_observed_justified_checkpoint]
 ```
 
 #### LMD-GHOST helpers
@@ -585,23 +644,23 @@ to be assumed from the time of the first run of the algorithm which could happen
 big number of epochs ago.
 
 ```python
-def is_confirmed_chain_safe(store: Store, confirmed_root: Root) -> bool:
+def is_confirmed_chain_safe(fcr_store: FastConfirmationStore, confirmed_root: Root) -> bool:
     """
     Return ``True`` if and only if all blocks of the confirmed chain
     starting from current_epoch_observed_justified_checkpoint are LMD-GHOST safe.
     """
-
+    store = fcr_store.store
     # Check if the confirmed_root is descendant of current_epoch_observed_justified_checkpoint.
     if not is_ancestor(
-        store, confirmed_root, store.current_epoch_observed_justified_checkpoint.root
+        store, confirmed_root, fcr_store.current_epoch_observed_justified_checkpoint.root
     ):
         return False
 
     current_epoch = get_current_store_epoch(store)
-    if store.current_epoch_observed_justified_checkpoint.epoch + 1 >= current_epoch:
+    if fcr_store.current_epoch_observed_justified_checkpoint.epoch + 1 >= current_epoch:
         # Exclude the justified checkpoint block if it is from the previous epoch
         # as then this block will always be canonical in this case.
-        start_root_exclusive = store.current_epoch_observed_justified_checkpoint.root
+        start_root_exclusive = fcr_store.current_epoch_observed_justified_checkpoint.root
     else:
         # Limit reconfirmation to the first block of the previous epoch
         # as if it's successful, reconfirmation of the ancestors is implied.
@@ -618,7 +677,8 @@ def is_confirmed_chain_safe(store: Store, confirmed_root: Root) -> bool:
     # Run is_one_confirmed for each block in the confirmed chain with the previous epoch balance source.
     chain_roots = get_ancestor_roots(store, confirmed_root, start_root_exclusive)
     return all(
-        is_one_confirmed(store, get_previous_balance_source(store), root) for root in chain_roots
+        is_one_confirmed(store, get_previous_balance_source(fcr_store), root)
+        for root in chain_roots
     )
 ```
 
@@ -749,22 +809,25 @@ def will_current_target_be_justified(store: Store) -> bool:
 *Note:* This function updates variables used by the fast confirmation rule.
 
 ```python
-def update_fast_confirmation_variables(store: Store) -> None:
+def update_fast_confirmation_variables(fcr_store: FastConfirmationStore) -> None:
     # Update prev and curr slot head.
-    store.previous_slot_head = store.current_slot_head
-    store.current_slot_head = get_head(store)
+    store = fcr_store.store
+    fcr_store.previous_slot_head = fcr_store.current_slot_head
+    fcr_store.current_slot_head = get_head(store)
 
     # Update greatest unrealized justified checkpoint at the last slot of an epoch.
     if is_start_slot_at_epoch(Slot(get_current_slot(store) + 1)):
-        store.previous_epoch_greatest_unrealized_checkpoint = store.unrealized_justified_checkpoint
+        fcr_store.previous_epoch_greatest_unrealized_checkpoint = (
+            store.unrealized_justified_checkpoint
+        )
 
     # Update observed justified checkpoints at the start of an epoch.
     if is_start_slot_at_epoch(get_current_slot(store)):
-        store.previous_epoch_observed_justified_checkpoint = (
-            store.current_epoch_observed_justified_checkpoint
+        fcr_store.previous_epoch_observed_justified_checkpoint = (
+            fcr_store.current_epoch_observed_justified_checkpoint
         )
-        store.current_epoch_observed_justified_checkpoint = (
-            store.previous_epoch_greatest_unrealized_checkpoint
+        fcr_store.current_epoch_observed_justified_checkpoint = (
+            fcr_store.previous_epoch_greatest_unrealized_checkpoint
         )
 ```
 
@@ -788,24 +851,27 @@ This function works correctly only if the `latest_confirmed_root` belongs to the
 canonical chain and is either from the previous or from the current epoch.
 
 ```python
-def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) -> Root:
+def find_latest_confirmed_descendant(
+    fcr_store: FastConfirmationStore, latest_confirmed_root: Root
+) -> Root:
     """
     Return the most recent confirmed block in the suffix of the canonical chain
     starting from ``latest_confirmed_root``.
     """
+    store = fcr_store.store
     head = get_head(store)
     current_epoch = get_current_store_epoch(store)
     confirmed_root = latest_confirmed_root
 
     if (
         get_block_epoch(store, confirmed_root) + 1 == current_epoch
-        and get_voting_source(store, store.previous_slot_head).epoch + 2 >= current_epoch
+        and get_voting_source(store, fcr_store.previous_slot_head).epoch + 2 >= current_epoch
         and (
             is_start_slot_at_epoch(get_current_slot(store))
             or (
                 will_no_conflicting_checkpoint_be_justified(store)
                 and (
-                    store.unrealized_justifications[store.previous_slot_head].epoch + 1
+                    store.unrealized_justifications[fcr_store.previous_slot_head].epoch + 1
                     >= current_epoch
                     or store.unrealized_justifications[head].epoch + 1 >= current_epoch
                 )
@@ -828,10 +894,10 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
 
             # The algorithm can only rely on the previous head
             # if it is a descendant of the block that is attempted to be confirmed
-            if not is_ancestor(store, store.previous_slot_head, block_root):
+            if not is_ancestor(store, fcr_store.previous_slot_head, block_root):
                 break
 
-            if not is_one_confirmed(store, get_current_balance_source(store), block_root):
+            if not is_one_confirmed(store, get_current_balance_source(fcr_store), block_root):
                 break
 
             confirmed_root = block_root
@@ -857,7 +923,7 @@ def find_latest_confirmed_descendant(store: Store, latest_confirmed_root: Root) 
                 if not will_current_target_be_justified(store):
                     break
 
-            if not is_one_confirmed(store, get_current_balance_source(store), block_root):
+            if not is_one_confirmed(store, get_current_balance_source(fcr_store), block_root):
                 break
 
             tentative_confirmed_root = block_root
@@ -902,11 +968,12 @@ actions:
    `find_latest_confirmed_descendant`.
 
 ```python
-def get_latest_confirmed(store: Store) -> Root:
+def get_latest_confirmed(fcr_store: FastConfirmationStore) -> Root:
     """
     Return the most recent confirmed block by executing the FCR algorithm.
     """
-    confirmed_root = store.confirmed_root
+    store = fcr_store.store
+    confirmed_root = fcr_store.confirmed_root
     current_epoch = get_current_store_epoch(store)
 
     # Revert to finalized block if either of the following is true:
@@ -920,7 +987,7 @@ def get_latest_confirmed(store: Store) -> Root:
         or not is_ancestor(store, head, confirmed_root)
         or (
             is_start_slot_at_epoch(get_current_slot(store))
-            and not is_confirmed_chain_safe(store, confirmed_root)
+            and not is_confirmed_chain_safe(fcr_store, confirmed_root)
         )
     ):
         confirmed_root = store.finalized_checkpoint.root
@@ -932,13 +999,14 @@ def get_latest_confirmed(store: Store) -> Root:
     # 4) confirmed block is older than the block of store.current_epoch_observed_justified_checkpoint.
     is_epoch_start = is_start_slot_at_epoch(get_current_slot(store))
     observed_justified_block_slot = get_block_slot(
-        store, store.current_epoch_observed_justified_checkpoint.root
+        store, fcr_store.current_epoch_observed_justified_checkpoint.root
     )
     is_observed_justified_block_epoch_ok = (
         compute_epoch_at_slot(observed_justified_block_slot) + 1 == current_epoch
     )
     is_head_unrealized_justified_ok = (
-        store.current_epoch_observed_justified_checkpoint == store.unrealized_justifications[head]
+        fcr_store.current_epoch_observed_justified_checkpoint
+        == store.unrealized_justifications[head]
     )
     is_confirmed_block_stale = get_block_slot(store, confirmed_root) < observed_justified_block_slot
     if (
@@ -947,11 +1015,11 @@ def get_latest_confirmed(store: Store) -> Root:
         and is_head_unrealized_justified_ok
         and is_confirmed_block_stale
     ):
-        confirmed_root = store.current_epoch_observed_justified_checkpoint.root
+        confirmed_root = fcr_store.current_epoch_observed_justified_checkpoint.root
 
     # Attempt to further advance the latest confirmed block.
     if get_block_epoch(store, confirmed_root) + 1 >= current_epoch:
-        return find_latest_confirmed_descendant(store, confirmed_root)
+        return find_latest_confirmed_descendant(fcr_store, confirmed_root)
     else:
         return confirmed_root
 ```
@@ -987,7 +1055,7 @@ Implementations MAY call `get_latest_confirmed` at any point in time throughout
 a slot.
 
 ```python
-def on_fast_confirmation(store: Store) -> None:
-    update_fast_confirmation_variables(store)
-    store.confirmed_root = get_latest_confirmed(store)
+def on_fast_confirmation(fcr_store: FastConfirmationStore) -> None:
+    update_fast_confirmation_variables(fcr_store)
+    fcr_store.confirmed_root = get_latest_confirmed(fcr_store)
 ```

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -164,21 +164,6 @@ algorithm. The important fields being tracked are described below:
 - `unrealized_justifications`: stores a map of block root to the unrealized
   justified checkpoint observed in that block.
 
-The following fields are used by the Fast Confirmation Rule:
-
-- `confirmed_root`: root of the most recent confirmed block.
-- `previous_epoch_observed_justified_checkpoint`: a justified checkpoint that
-  has been observed by all honest nodes at the beginning of the previous epoch
-  assuming synchrony.
-- `current_epoch_observed_justified_checkpoint`: a justified checkpoint that has
-  been observed by all honest nodes at the beginning of the current epoch
-  assuming synchrony.
-- `previous_epoch_greatest_unrealized_checkpoint`: a greatest unrealized
-  justified checkpoint at the start of the last slot of the previous epoch
-  according to a local view.
-- `previous_slot_head`: the head at the start of the previous slot.
-- `current_slot_head`: the head at the start of the current slot.
-
 ```python
 @dataclass
 class Store(object):
@@ -189,12 +174,6 @@ class Store(object):
     unrealized_justified_checkpoint: Checkpoint
     unrealized_finalized_checkpoint: Checkpoint
     proposer_boost_root: Root
-    confirmed_root: Root
-    previous_epoch_observed_justified_checkpoint: Checkpoint
-    current_epoch_observed_justified_checkpoint: Checkpoint
-    previous_epoch_greatest_unrealized_checkpoint: Checkpoint
-    previous_slot_head: Root
-    current_slot_head: Root
     equivocating_indices: Set[ValidatorIndex]
     blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
     block_states: Dict[Root, BeaconState] = field(default_factory=dict)
@@ -231,12 +210,6 @@ def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -
         unrealized_justified_checkpoint=justified_checkpoint,
         unrealized_finalized_checkpoint=finalized_checkpoint,
         proposer_boost_root=proposer_boost_root,
-        confirmed_root=anchor_root,
-        previous_epoch_observed_justified_checkpoint=justified_checkpoint,
-        current_epoch_observed_justified_checkpoint=justified_checkpoint,
-        previous_epoch_greatest_unrealized_checkpoint=justified_checkpoint,
-        previous_slot_head=anchor_root,
-        current_slot_head=anchor_root,
         equivocating_indices=set(),
         blocks={anchor_root: copy(anchor_block)},
         block_states={anchor_root: copy(anchor_state)},

--- a/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/fast_confirmation.py
@@ -36,31 +36,31 @@ def debug_print(*args, **kwargs):
         print(*args, **kwargs)
 
 
-def output_fast_confirmation_checks(spec, store, test_steps):
-    basic_checks = get_basic_store_checks(spec, store)
+def output_fast_confirmation_checks(spec, fcr_store, test_steps):
+    basic_checks = get_basic_store_checks(spec, fcr_store.store)
     fcr_checks = {
         "previous_epoch_observed_justified_checkpoint": {
-            "epoch": int(store.previous_epoch_observed_justified_checkpoint.epoch),
-            "root": encode_hex(store.previous_epoch_observed_justified_checkpoint.root),
+            "epoch": int(fcr_store.previous_epoch_observed_justified_checkpoint.epoch),
+            "root": encode_hex(fcr_store.previous_epoch_observed_justified_checkpoint.root),
         },
         "current_epoch_observed_justified_checkpoint": {
-            "epoch": int(store.current_epoch_observed_justified_checkpoint.epoch),
-            "root": encode_hex(store.current_epoch_observed_justified_checkpoint.root),
+            "epoch": int(fcr_store.current_epoch_observed_justified_checkpoint.epoch),
+            "root": encode_hex(fcr_store.current_epoch_observed_justified_checkpoint.root),
         },
         "previous_epoch_greatest_unrealized_checkpoint": {
-            "epoch": int(store.previous_epoch_greatest_unrealized_checkpoint.epoch),
-            "root": encode_hex(store.previous_epoch_greatest_unrealized_checkpoint.root),
+            "epoch": int(fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch),
+            "root": encode_hex(fcr_store.previous_epoch_greatest_unrealized_checkpoint.root),
         },
-        "previous_slot_head": encode_hex(store.previous_slot_head),
-        "current_slot_head": encode_hex(store.current_slot_head),
-        "confirmed_root": encode_hex(store.confirmed_root),
+        "previous_slot_head": encode_hex(fcr_store.previous_slot_head),
+        "current_slot_head": encode_hex(fcr_store.current_slot_head),
+        "confirmed_root": encode_hex(fcr_store.confirmed_root),
     }
     test_steps.append({"checks": basic_checks | fcr_checks})
 
 
-def on_fast_confirmation_and_append_step(spec, store, test_steps):
-    spec.on_fast_confirmation(store)
-    output_fast_confirmation_checks(spec, store, test_steps)
+def on_fast_confirmation_and_append_step(spec, fcr_store, test_steps):
+    spec.on_fast_confirmation(fcr_store)
+    output_fast_confirmation_checks(spec, fcr_store, test_steps)
 
 
 def str_to_graffiti(graffiti: str) -> bytes:
@@ -80,9 +80,11 @@ class FCRTest:
         # Initialization
         test_steps = []
         store, anchor_block = get_genesis_forkchoice_store_and_block(self.spec, anchor_state)
+        fcr_store = self.spec.get_fast_confirmation_store(store)
 
         self.rng = Random(self.seed)
         self.store = store
+        self.fcr_store = fcr_store
         self.test_steps = test_steps
         self.attestation_pool = []
         self.recent_attestations = []
@@ -94,7 +96,7 @@ class FCRTest:
         self.blockchain_artefacts.append(("anchor_state", anchor_state))
         self.blockchain_artefacts.append(("anchor_block", anchor_block))
 
-        return store
+        return store, fcr_store
 
     def get_test_artefacts(self):
         return self.blockchain_artefacts + [("steps", self.test_steps)]
@@ -306,7 +308,7 @@ class FCRTest:
             self.spec.on_attestation(self.store, attestation, is_from_block=False)
 
     def run_fast_confirmation(self):
-        on_fast_confirmation_and_append_step(self.spec, self.store, self.test_steps)
+        on_fast_confirmation_and_append_step(self.spec, self.fcr_store, self.test_steps)
 
     def next_slot_with_block(
         self,
@@ -401,7 +403,7 @@ class FCRTest:
         return attester_slashing
 
     def compute_score_and_threshold(self, block_root) -> (int, int):
-        balance_source = self.spec.get_current_balance_source(self.store)
+        balance_source = self.spec.get_current_balance_source(self.fcr_store)
         score = self.spec.get_attestation_score(self.store, block_root, balance_source)
         safety_threshold = self.spec.compute_safety_threshold(
             self.store, block_root, balance_source
@@ -431,8 +433,9 @@ class FCRTest:
 
         spec = self.spec
         store = self.store
+        fcr_store = self.fcr_store
 
-        balance_source = spec.get_current_balance_source(store)
+        balance_source = spec.get_current_balance_source(fcr_store)
         total_active_balance = spec.get_total_active_balance(balance_source)
         one_committee_weight = int(total_active_balance // spec.SLOTS_PER_EPOCH)
 
@@ -444,7 +447,7 @@ class FCRTest:
             # Genesis block
             if spec.get_block_slot(store, block_root) == spec.GENESIS_SLOT:
                 genesis_info = self.get_slot_root_info(block_root)
-                if block_root == store.confirmed_root:
+                if block_root == fcr_store.confirmed_root:
                     return f"\033[94m({genesis_info})\033[0m"
                 else:
                     return f"\033[92m({genesis_info})\033[0m"
@@ -452,7 +455,7 @@ class FCRTest:
             score, threshold = get_relative_score_and_threshold(block_root)
             output = f"({self.get_slot_root_info(block_root)}, uj={store.unrealized_justifications[block_root].epoch}, sc={score:.1f}%, th={threshold:.1f}%)"
 
-            if block_root == store.confirmed_root:
+            if block_root == fcr_store.confirmed_root:
                 # Confirmed block in Blue if can be re-confirmed, Magenta otherwise
                 if score > threshold:
                     return f"\033[94m{output}\033[0m"
@@ -494,6 +497,7 @@ class FCRTest:
 
         spec = self.spec
         store = self.store
+        fcr_store = self.fcr_store
 
         # Print epoch and slot
         print(
@@ -514,8 +518,8 @@ class FCRTest:
             uj = store.unrealized_justifications[head_root]
             return f"{self.get_slot_root_info(head_root)}, vs=({self.get_checkpoint_info(vs)}), uj=({self.get_checkpoint_info(uj)})"
 
-        print(f"\nprev_head [{get_head_info(store.previous_slot_head)}]")
-        print(f"curr_head [{get_head_info(store.current_slot_head)}]")
+        print(f"\nprev_head [{get_head_info(fcr_store.previous_slot_head)}]")
+        print(f"curr_head [{get_head_info(fcr_store.current_slot_head)}]")
         print(f"head      [{get_head_info(self.head())}]")
 
         # Print prev epoch GU and current target
@@ -529,7 +533,7 @@ class FCRTest:
             f"\ncurr_target [{self.get_checkpoint_info(curr_target)}, ffg_support={relative_support:.1f}%]"
         )
         print(
-            f"prev_epoch_gu [{self.get_checkpoint_info(store.previous_epoch_greatest_unrealized_checkpoint)}]"
+            f"prev_epoch_gu [{self.get_checkpoint_info(fcr_store.previous_epoch_greatest_unrealized_checkpoint)}]"
         )
         print(f"justified_checkpoint [{self.get_checkpoint_info(store.justified_checkpoint)}]")
         print(f"finalized_checkpoint [{self.get_checkpoint_info(store.finalized_checkpoint)}]")

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_basic.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_basic.py
@@ -23,10 +23,10 @@ from eth2spec.test.helpers.fast_confirmation import (
 @single_phase
 def test_fast_confirm_an_epoch(spec, state):
     fcr_test = FCRTest(spec, seed=1)
-    store = fcr_test.initialize(state)
+    store, fcr_store = fcr_test.initialize(state)
     for _ in range(spec.SLOTS_PER_EPOCH):
         fcr_test.next_slot_with_block_and_fast_confirmation()
         # Ensure head is confirmed
-        assert store.confirmed_root == fcr_test.head()
+        assert fcr_store.confirmed_root == fcr_test.head()
 
     yield from fcr_test.get_test_artefacts()

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_current_epoch.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_current_epoch.py
@@ -30,12 +30,13 @@ class CurrentEpochTestSpecification:
         bool  # <-> is_one_confirmed(store, get_current_balance_source(store), block_root)
     ) = False
 
-    def verify_preconditions(self, spec, store):
+    def verify_preconditions(self, spec, fcr_store):
+        store = fcr_store.store
         head = spec.get_head(store)
         current_epoch = spec.get_current_store_epoch(store)
         current_slot = spec.get_current_slot(store)
-        confirmed_epoch = spec.get_block_epoch(store, store.confirmed_root)
-        canonical_roots = spec.get_ancestor_roots(store, head, store.confirmed_root)
+        confirmed_epoch = spec.get_block_epoch(store, fcr_store.confirmed_root)
+        canonical_roots = spec.get_ancestor_roots(store, head, fcr_store.confirmed_root)
 
         assert confirmed_epoch + 1 >= current_epoch
         assert current_slot % spec.SLOTS_PER_EPOCH > 0
@@ -49,28 +50,29 @@ class CurrentEpochTestSpecification:
         assert self.target_will_be_justified == spec.will_current_target_be_justified(store)
         if self.is_one_confirmed:
             is_one_confirmed_list = [
-                spec.is_one_confirmed(store, spec.get_current_balance_source(store), root)
+                spec.is_one_confirmed(store, spec.get_current_balance_source(fcr_store), root)
                 for root in canonical_roots
             ]
             assert all(is_one_confirmed_list)
         else:
             assert not spec.is_one_confirmed(
-                store, spec.get_current_balance_source(store), spec.get_head(store)
+                store, spec.get_current_balance_source(fcr_store), spec.get_head(store)
             )
 
-    def get_expected_confirmed_root(self, spec, store):
-        confirmed_epoch = spec.get_block_epoch(store, store.confirmed_root)
+    def get_expected_confirmed_root(self, spec, fcr_store):
+        store = fcr_store.store
+        confirmed_epoch = spec.get_block_epoch(store, fcr_store.confirmed_root)
         current_epoch = spec.get_current_store_epoch(store)
 
         if confirmed_epoch < current_epoch and not self.target_will_be_justified:
-            return store.confirmed_root
+            return fcr_store.confirmed_root
 
         if self.head_uj_fresh and self.is_one_confirmed:
             # If any block is supposed to be confirmed
             # the head is always expected to be the most recent confirmed one
             return spec.get_head(store)
         else:
-            return store.confirmed_root
+            return fcr_store.confirmed_root
 
     def first_block_at_mid_epoch(self):
         return self.first_block_in_epoch and not self.second_slot_call
@@ -243,17 +245,19 @@ class CurrentEpochTestBuilder:
             fcr_test.print_fast_confirmation_state()
 
         # Check preconditions are correct
-        self.test_spec.verify_preconditions(fcr_test.spec, fcr_test.store)
+        self.test_spec.verify_preconditions(fcr_test.spec, fcr_test.fcr_store)
 
         return fcr_test
 
 
 def run_current_epoch_test(fcr_test: FCRTest, test_spec: CurrentEpochTestSpecification):
     # Keep expected confirmed_root after execution of the test
-    exptected_confirmed_root = test_spec.get_expected_confirmed_root(fcr_test.spec, fcr_test.store)
+    exptected_confirmed_root = test_spec.get_expected_confirmed_root(
+        fcr_test.spec, fcr_test.fcr_store
+    )
     # Execute FCR and check that confirmed_root is as expected
     fcr_test.run_fast_confirmation()
-    assert fcr_test.store.confirmed_root == exptected_confirmed_root
+    assert fcr_test.fcr_store.confirmed_root == exptected_confirmed_root
 
     yield from fcr_test.get_test_artefacts()
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_empty_slots.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_empty_slots.py
@@ -38,12 +38,12 @@ def test_fcr_handles_single_empty_slot(spec, state):
        - Chain continues normally and confirmations advance after empty slot
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     # Build normally for first few slots
     fcr.run_slots_with_blocks_and_fast_confirmation(number_of_slots=4, participation_rate=100)
 
-    confirmed_before_empty = store.confirmed_root
+    confirmed_before_empty = fcr_store.confirmed_root
     head_before_empty = fcr.head()
 
     # With 100% participation, head should be confirmed
@@ -58,10 +58,10 @@ def test_fcr_handles_single_empty_slot(spec, state):
     assert fcr.head() == head_before_empty, "Head should not change during empty slot"
 
     # Verify slot head variables still updated
-    assert store.current_slot_head == head_before_empty
+    assert fcr_store.current_slot_head == head_before_empty
 
     # Confirmed should stay at head_before_empty (no reset)
-    assert store.confirmed_root == head_before_empty, (
+    assert fcr_store.confirmed_root == head_before_empty, (
         "confirmed_root should stay at head_before_empty during empty slot"
     )
 
@@ -83,7 +83,7 @@ def test_fcr_handles_single_empty_slot(spec, state):
 
     # Verify expected final state
     assert fcr.head() == next_block
-    assert store.confirmed_root == next_block, "confirmed_root should be next_block"
+    assert fcr_store.confirmed_root == next_block, "confirmed_root should be next_block"
 
     yield from fcr.get_test_artefacts()
 
@@ -110,13 +110,13 @@ def test_fcr_handles_multiple_consecutive_empty_slots(spec, state):
     4. Verify confirmations still work correctly
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     # Build normally for first few slots
     fcr.run_slots_with_blocks_and_fast_confirmation(number_of_slots=4, participation_rate=100)
 
     head_before_empty = fcr.head()
-    confirmed_before_empty = store.confirmed_root
+    confirmed_before_empty = fcr_store.confirmed_root
 
     # With 100% participation, head should be confirmed
     assert confirmed_before_empty == head_before_empty
@@ -130,7 +130,7 @@ def test_fcr_handles_multiple_consecutive_empty_slots(spec, state):
 
         # Head unchanged, confirmed stays at head_before_empty
         assert fcr.head() == head_before_empty
-        assert store.confirmed_root == head_before_empty
+        assert fcr_store.confirmed_root == head_before_empty
 
     # Resume: propose block that skips multiple slots
     block_after_empty = fcr.next_slot_with_block_and_fast_confirmation(
@@ -151,7 +151,7 @@ def test_fcr_handles_multiple_consecutive_empty_slots(spec, state):
 
     # Verify expected final state
     assert fcr.head() == second_block
-    assert store.confirmed_root == second_block
+    assert fcr_store.confirmed_root == second_block
 
     yield from fcr.get_test_artefacts()
 
@@ -182,7 +182,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
        - No spurious resets
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     last_slot_epoch0 = S - 1
@@ -195,9 +195,9 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
     assert fcr.current_slot() == last_slot_epoch0 - 1  # slot 6
 
     head_before_empty = fcr.head()
-    confirmed_before_empty = store.confirmed_root
-    current_observed_before = store.current_epoch_observed_justified_checkpoint
-    previous_observed_before = store.previous_epoch_observed_justified_checkpoint
+    confirmed_before_empty = fcr_store.confirmed_root
+    current_observed_before = fcr_store.current_epoch_observed_justified_checkpoint
+    previous_observed_before = fcr_store.previous_epoch_observed_justified_checkpoint
 
     # With 100% participation, head should be confirmed
     assert confirmed_before_empty == head_before_empty
@@ -216,24 +216,25 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     # GU snapshot should have been taken
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
+        fcr_store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
     ), "GU snapshot should be taken at last slot of epoch even during empty slot"
 
     # Observed checkpoints should NOT have rotated (PR #25 fix)
-    assert store.current_epoch_observed_justified_checkpoint == current_observed_before, (
+    assert fcr_store.current_epoch_observed_justified_checkpoint == current_observed_before, (
         "current_epoch_observed should NOT change at last slot of epoch"
     )
-    assert store.previous_epoch_observed_justified_checkpoint == previous_observed_before, (
+    assert fcr_store.previous_epoch_observed_justified_checkpoint == previous_observed_before, (
         "previous_epoch_observed should NOT change at last slot of epoch"
     )
 
     # Head unchanged (empty slot), confirmed stays the same
     assert fcr.head() == head_before_empty
-    assert store.confirmed_root == head_before_empty
+    assert fcr_store.confirmed_root == head_before_empty
 
     # Record values before crossing into epoch 1
-    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
-    curr_observed_before_rotation = store.current_epoch_observed_justified_checkpoint
+    gu_snapshot = fcr_store.previous_epoch_greatest_unrealized_checkpoint
+    curr_observed_before_rotation = fcr_store.current_epoch_observed_justified_checkpoint
 
     # Attest at slot 7, then cross into epoch 1 (slot 8) WITH A BLOCK
     fcr.attest_and_next_slot_with_fast_confirmation(
@@ -244,10 +245,10 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
     assert spec.is_start_slot_at_epoch(fcr.current_slot())
 
     # Rotation should have happened at epoch start
-    assert store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation, (
-        "previous_observed should now equal old current_observed after rotation at epoch start"
-    )
-    assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+    assert (
+        fcr_store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation
+    ), "previous_observed should now equal old current_observed after rotation at epoch start"
+    assert fcr_store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
         "current_observed should now equal GU snapshot after rotation at epoch start"
     )
 
@@ -259,7 +260,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     assert fcr.head() == first_block_epoch1
     # Confirmed hasn't caught up yet
-    assert store.confirmed_root == head_before_empty
+    assert fcr_store.confirmed_root == head_before_empty
 
     # Continue to next slot
     fcr.next_slot()
@@ -271,7 +272,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
 
     assert fcr.head() == second_block
     # Confirmed still hasn't caught up
-    assert store.confirmed_root == head_before_empty
+    assert fcr_store.confirmed_root == head_before_empty
 
     # Apply attestations for second block
     fcr.next_slot()
@@ -282,7 +283,7 @@ def test_fcr_empty_slot_at_epoch_boundary(spec, state):
     # the epoch boundary, confirmation catches up after the second block's
     # attestations are applied.
     assert fcr.head() == second_block
-    assert store.confirmed_root == second_block
+    assert fcr_store.confirmed_root == second_block
 
     yield from fcr.get_test_artefacts()
 
@@ -317,7 +318,7 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
        - Confirmations continue after resuming blocks
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     last_slot_epoch0 = S - 1  # slot 7 in MINIMAL
@@ -332,8 +333,8 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     head_slot = store.blocks[head_before_empty].slot
     assert head_slot == 5, f"Last block should be at slot 5, got {head_slot}"
 
-    current_observed_before = store.current_epoch_observed_justified_checkpoint
-    previous_observed_before = store.previous_epoch_observed_justified_checkpoint
+    current_observed_before = fcr_store.current_epoch_observed_justified_checkpoint
+    previous_observed_before = fcr_store.previous_epoch_observed_justified_checkpoint
 
     # Slot 6: EMPTY
     fcr.attest_and_next_slot_with_fast_confirmation(
@@ -348,22 +349,23 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
 
     # GU snapshot should have been taken
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
+        fcr_store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
     ), "GU snapshot should be taken at last slot of epoch"
 
     # Observed checkpoints should NOT have rotated (PR #25)
-    assert store.current_epoch_observed_justified_checkpoint == current_observed_before, (
+    assert fcr_store.current_epoch_observed_justified_checkpoint == current_observed_before, (
         "current_epoch_observed should NOT change at last slot of epoch"
     )
-    assert store.previous_epoch_observed_justified_checkpoint == previous_observed_before, (
+    assert fcr_store.previous_epoch_observed_justified_checkpoint == previous_observed_before, (
         "previous_epoch_observed should NOT change at last slot of epoch"
     )
 
     assert fcr.head() == head_before_empty
 
     # Record values before crossing into epoch 1
-    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
-    curr_observed_before_rotation = store.current_epoch_observed_justified_checkpoint
+    gu_snapshot = fcr_store.previous_epoch_greatest_unrealized_checkpoint
+    curr_observed_before_rotation = fcr_store.current_epoch_observed_justified_checkpoint
 
     fcr.attest(block_root=head_before_empty, slot=fcr.current_slot(), participation_rate=100)
 
@@ -378,10 +380,10 @@ def test_fcr_empty_slots_at_epoch_boundary_both_sides(spec, state):
     assert fcr.head() == head_before_empty
 
     # Rotation should have happened at epoch start
-    assert store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation, (
-        "previous_observed should now equal old current_observed after rotation at epoch start"
-    )
-    assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+    assert (
+        fcr_store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation
+    ), "previous_observed should now equal old current_observed after rotation at epoch start"
+    assert fcr_store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
         "current_observed should now equal GU snapshot after rotation at epoch start"
     )
 
@@ -441,7 +443,7 @@ def test_fcr_slot_head_tracking_during_empty_slots(spec, state):
     3. Verify slot head variables update correctly each slot
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     # Build a few blocks
     fcr.run_slots_with_blocks_and_fast_confirmation(number_of_slots=3, participation_rate=100)
@@ -452,7 +454,7 @@ def test_fcr_slot_head_tracking_during_empty_slots(spec, state):
     slot_head_history = []
 
     for _ in range(4):  # 4 empty slots
-        curr_head_before = store.current_slot_head
+        curr_head_before = fcr_store.current_slot_head
         fcr.attest_and_next_slot_with_fast_confirmation(
             block_root=last_block_head, participation_rate=100
         )
@@ -460,8 +462,8 @@ def test_fcr_slot_head_tracking_during_empty_slots(spec, state):
         slot_head_history.append(
             {
                 "slot": int(fcr.current_slot()),
-                "previous_slot_head": store.previous_slot_head,
-                "current_slot_head": store.current_slot_head,
+                "previous_slot_head": fcr_store.previous_slot_head,
+                "current_slot_head": fcr_store.current_slot_head,
                 "head": fcr.head(),
             }
         )
@@ -470,10 +472,10 @@ def test_fcr_slot_head_tracking_during_empty_slots(spec, state):
         assert fcr.head() == last_block_head
 
         # current_slot_head should equal head (which is unchanged)
-        assert store.current_slot_head == last_block_head
+        assert fcr_store.current_slot_head == last_block_head
 
         # previous_slot_head should equal what current_slot_head was before update
-        assert store.previous_slot_head == curr_head_before
+        assert fcr_store.previous_slot_head == curr_head_before
 
     # All slot heads should point to the same block during empty slots
     for record in slot_head_history:

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_ffg.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_ffg.py
@@ -36,7 +36,7 @@ def test_will_no_conflicting_checkpoint_be_justified_fails_at_strictly_one_third
     4. Check the one_confirmed passes for a block but will_no_conflicting_checkpoint_be_justified fails
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -44,7 +44,7 @@ def test_will_no_conflicting_checkpoint_be_justified_fails_at_strictly_one_third
     target_slot = 2 * S - 1
     fcr.run_slots_with_blocks_and_fast_confirmation(target_slot, participation_rate=100)
 
-    confirmed_epoch_2_last_slot = store.confirmed_root
+    confirmed_epoch_2_last_slot = fcr_store.confirmed_root
 
     # Epoch 2, Last Slot with participation enough pass reconfirmation, but still not enoug to confirm
     target_root = fcr.next_slot_with_block_and_fast_confirmation(
@@ -87,14 +87,14 @@ def test_will_no_conflicting_checkpoint_be_justified_fails_at_strictly_one_third
     )
 
     # Check all other conditions passes, so a block would be confirmed
-    assert spec.is_one_confirmed(store, spec.get_current_balance_source(store), target_root)
+    assert spec.is_one_confirmed(store, spec.get_current_balance_source(fcr_store), target_root)
     assert spec.get_voting_source(
-        store, store.previous_slot_head
+        store, fcr_store.previous_slot_head
     ).epoch + 2 >= spec.get_current_store_epoch(store)
     assert store.unrealized_justifications[
         spec.get_head(store)
     ].epoch + 1 >= spec.get_current_store_epoch(store)
-    assert spec.is_ancestor(store, store.previous_slot_head, target_root)
+    assert spec.is_ancestor(store, fcr_store.previous_slot_head, target_root)
 
     # Check will_no_conflicting_checkpoint_be_justified fails
     assert not spec.will_no_conflicting_checkpoint_be_justified(store)
@@ -102,7 +102,7 @@ def test_will_no_conflicting_checkpoint_be_justified_fails_at_strictly_one_third
     # Run Fast confirmation
     fcr.run_fast_confirmation()
 
-    assert store.confirmed_root == confirmed_epoch_2_last_slot
+    assert fcr_store.confirmed_root == confirmed_epoch_2_last_slot
 
     yield from fcr.get_test_artefacts()
 
@@ -129,7 +129,7 @@ def test_will_current_target_be_justified_passes_at_strictly_two_third(spec, sta
        3 * honest_ffg_support_for_current_target == 2 * total_active_balance
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -162,11 +162,11 @@ def test_will_current_target_be_justified_passes_at_strictly_two_third(spec, sta
     # Check will_current_target_be_justified passes
     assert spec.will_current_target_be_justified(store)
 
-    assert store.confirmed_root == confirmed_epoch_1_last_slot
+    assert fcr_store.confirmed_root == confirmed_epoch_1_last_slot
 
     # Run Fast confirmation
     fcr.run_fast_confirmation()
 
-    assert store.confirmed_root == chkp_root
+    assert fcr_store.confirmed_root == chkp_root
 
     yield from fcr.get_test_artefacts()

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_is_one_confirmed.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_is_one_confirmed.py
@@ -36,7 +36,7 @@ def test_is_one_confirmed_passes_with_full_participation(spec, state):
     4. Inspect the individual terms of the inequality
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -52,7 +52,7 @@ def test_is_one_confirmed_passes_with_full_participation(spec, state):
     assert parent_block.slot + 1 == block.slot, "Test requires consecutive slots"
 
     # Get balance source
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # Call is_one_confirmed directly
     assert spec.is_one_confirmed(store, balance_source, block_b), (
@@ -103,7 +103,7 @@ def test_is_one_confirmed_fails_with_low_participation(spec, state):
     4. Inspect the terms to verify support is insufficient
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -119,7 +119,7 @@ def test_is_one_confirmed_fails_with_low_participation(spec, state):
     assert parent_block.slot + 1 == block.slot, "Test requires consecutive slots"
 
     # Get balance source
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # Call is_one_confirmed directly
     assert not spec.is_one_confirmed(store, balance_source, block_b), (
@@ -171,7 +171,7 @@ def test_is_one_confirmed_slashing_supporters_does_not_hurt(spec, state):
     3. Verify is_one_confirmed remains True
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -191,7 +191,9 @@ def test_is_one_confirmed_slashing_supporters_does_not_hurt(spec, state):
     fcr.run_fast_confirmation()
 
     # is_one_confirmed must still hold
-    assert store.confirmed_root == block_b, "Slashing supporters should not break is_one_confirmed"
+    assert fcr_store.confirmed_root == block_b, (
+        "Slashing supporters should not break is_one_confirmed"
+    )
 
     yield from fcr.get_test_artefacts()
 
@@ -229,7 +231,7 @@ def test_is_one_confirmed_slashing_non_supporters_helps(spec, state):
     4. Verify support unchanged, adversarial budget decreased, is_one_confirmed flips to True
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -243,7 +245,7 @@ def test_is_one_confirmed_slashing_non_supporters_helps(spec, state):
     parent_block = store.blocks[block.parent_root]
     assert parent_block.slot + 1 == block.slot, "Test requires consecutive slots"
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     support_before = spec.get_attestation_score(store, block_b, balance_source)
     adversarial_weight_before = spec.get_adversarial_weight(store, balance_source, block_b)
@@ -313,7 +315,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
        passing for the gapped block
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -327,7 +329,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     parent_a = store.blocks[block_a_data.parent_root]
     assert parent_a.slot + 1 == block_a_data.slot, "Block A must be consecutive"
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     discount_a = spec.get_support_discount(store, balance_source, block_a)
     assert discount_a == 0, f"Block A discount should be 0, got {discount_a}"
@@ -353,7 +355,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     parent_b = store.blocks[block_b_data.parent_root]
     assert parent_b.slot + 1 < block_b_data.slot, "Block B must have an empty slot gap"
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # Discount must be positive
     discount_b = int(spec.get_support_discount(store, balance_source, block_b))
@@ -388,7 +390,7 @@ def test_is_one_confirmed_empty_slot_discount(spec, state):
     # Accumulate one more slot of attestations to dilute proposer boost.
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=100)
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # With accumulation, block_b should now pass
     assert spec.is_one_confirmed(store, balance_source, block_b), (
@@ -449,7 +451,7 @@ def test_is_one_confirmed_support_accumulates_over_slots(spec, state):
     4. At s+2: verify is_one_confirmed passes (boost diluted by second committee)
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -459,7 +461,7 @@ def test_is_one_confirmed_support_accumulates_over_slots(spec, state):
     # Propose block B with 88% participation
     block_b = fcr.next_slot_with_block_and_fast_confirmation(participation_rate=88)
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # At s+1: one slot of support — fails due to proposer boost
     assert not spec.is_one_confirmed(store, balance_source, block_b), (
@@ -469,7 +471,7 @@ def test_is_one_confirmed_support_accumulates_over_slots(spec, state):
     # Attest 88% to B at s+1, advance to s+2, apply, run FCR — no new block
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=88)
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # At s+2: two slots of support — boost diluted, passes
     assert spec.is_one_confirmed(store, balance_source, block_b), (
@@ -505,7 +507,7 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
     5. Check is_one_confirmed with accumulated support
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -533,7 +535,7 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
         f"Block must cross epoch boundary: block_epoch={block_epoch}, parent_epoch={parent_block_epoch}"
     )
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # Verify adversarial weight uses epoch start as start_slot
     current_slot = spec.get_current_slot(store)
@@ -572,7 +574,7 @@ def test_is_one_confirmed_epoch_crossing_block(spec, state):
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=100)
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=100)
 
-    assert store.confirmed_root == block_b, (
+    assert fcr_store.confirmed_root == block_b, (
         "Epoch-crossing block should pass is_one_confirmed with accumulated support"
     )
 
@@ -609,7 +611,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     6. Verify B2 still fails throughout
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -633,7 +635,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     fcr.next_slot()
     fcr.run_fast_confirmation()
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # Both must have some support
     support_b1 = int(spec.get_attestation_score(store, block_b1, balance_source))
@@ -652,7 +654,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     # Accumulate support for B1 only — first additional slot
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b1, participation_rate=100)
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # B1 still fails after one additional slot (initial split deficit too large)
     assert not spec.is_one_confirmed(store, balance_source, block_b1), (
@@ -665,7 +667,7 @@ def test_is_one_confirmed_fails_with_competing_branch(spec, state):
     # Accumulate support for B1 only — second additional slot
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b1, participation_rate=100)
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
 
     # B1 now passes — enough accumulated support overcomes the split deficit
     assert spec.is_one_confirmed(store, balance_source, block_b1), (
@@ -705,14 +707,14 @@ def test_is_confirmed_chain_safe_passes_full_chain(spec, state):
     4. Every individual block in the chain passes is_one_confirmed
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
     # Build through epoch 2 with 100% participation
     fcr.run_slots_with_blocks_and_fast_confirmation(3 * S, participation_rate=100)
 
-    confirmed_root = store.confirmed_root
+    confirmed_root = fcr_store.confirmed_root
 
     # Confirmed root must have advanced beyond genesis
     assert confirmed_root != state.latest_block_header.parent_root, (
@@ -720,15 +722,15 @@ def test_is_confirmed_chain_safe_passes_full_chain(spec, state):
     )
 
     # Verify is_confirmed_chain_safe passes
-    assert spec.is_confirmed_chain_safe(store, confirmed_root), (
+    assert spec.is_confirmed_chain_safe(fcr_store, confirmed_root), (
         "is_confirmed_chain_safe should pass with 100% participation"
     )
 
     # Walk the chain from confirmed_root back toward the anchor and verify
     # each block individually passes is_one_confirmed
-    balance_source = spec.get_previous_balance_source(store)
+    balance_source = spec.get_previous_balance_source(fcr_store)
     block_root = confirmed_root
-    anchor_root = store.previous_epoch_observed_justified_checkpoint.root
+    anchor_root = fcr_store.previous_epoch_observed_justified_checkpoint.root
     blocks_checked = 0
 
     while block_root != anchor_root:
@@ -782,7 +784,7 @@ def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
     6. Verify it WOULD be confirmed with the narrower (incorrect) range
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -818,7 +820,7 @@ def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
     for _ in range(2):
         fcr.attest_and_next_slot_with_fast_confirmation(block_root=block_b, participation_rate=88)
 
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
     current_slot = spec.get_current_slot(store)
     total_active_balance = spec.get_total_active_balance(balance_source)
 
@@ -866,7 +868,7 @@ def test_is_one_confirmed_epoch_crossing_adversarial_range_matters(spec, state):
     )
 
     # confirmed_root should NOT include block_b
-    assert store.confirmed_root != block_b, (
+    assert fcr_store.confirmed_root != block_b, (
         "confirmed_root should not advance to the epoch-crossing block"
     )
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_previous_epoch.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_previous_epoch.py
@@ -22,41 +22,41 @@ from eth2spec.test.helpers.fast_confirmation import (
 
 @dataclass
 class PreviousEpochTestSpecification:
-    prev_head_ancestor: bool  # is_ancestor(store, store.previous_slot_head, block_root)
+    prev_head_ancestor: bool  # is_ancestor(store, fcr_store.previous_slot_head, block_root)
     first_slot_call: bool  # is_start_slot_at_epoch(get_current_slot(store))
     is_one_confirmed: bool  # is_one_confirmed(store, get_current_balance_source(store), block_root)
     no_conflicting_chkp: bool  # will_no_conflicting_checkpoint_be_justified(store)
     prev_head_vs_fresh: (
-        bool  # get_voting_source(store, store.previous_slot_head).epoch + 2 >= current_epoch
+        bool  # get_voting_source(store, fcr_store.previous_slot_head).epoch + 2 >= current_epoch
     )
-    prev_head_uj_fresh: (
-        bool  # store.unrealized_justifications[store.previous_slot_head].epoch + 1 >= current_epoch
-    )
+    prev_head_uj_fresh: bool  # store.unrealized_justifications[fcr_store.previous_slot_head].epoch + 1 >= current_epoch
     block_vs_fresh: (
         bool  # get_voting_source(store, tentative_confirmed_root).epoch + 2 >= current_epoch
     )
     head_uj_fresh: bool  # store.unrealized_justifications[head].epoch + 1 >= current_epoch
 
-    def get_prev_epoch_canonical_roots(self, spec, store):
+    def get_prev_epoch_canonical_roots(self, spec, fcr_store):
+        store = fcr_store.store
         head = spec.get_head(store)
         current_epoch = spec.get_current_store_epoch(store)
-        canonical_roots = spec.get_ancestor_roots(store, head, store.confirmed_root)
+        canonical_roots = spec.get_ancestor_roots(store, head, fcr_store.confirmed_root)
         return [
             root
             for root in canonical_roots
             if spec.get_block_epoch(store, root) + 1 == current_epoch
         ]
 
-    def verify_preconditions(self, spec, store):
+    def verify_preconditions(self, spec, fcr_store):
+        store = fcr_store.store
         head = spec.get_head(store)
         current_epoch = spec.get_current_store_epoch(store)
         current_slot = spec.get_current_slot(store)
-        confirmed_epoch = spec.get_block_epoch(store, store.confirmed_root)
-        prev_epoch_canonical_roots = self.get_prev_epoch_canonical_roots(spec, store)
-        # store.prev_slot_head = store.current_slot_head will become True
+        confirmed_epoch = spec.get_block_epoch(store, fcr_store.confirmed_root)
+        prev_epoch_canonical_roots = self.get_prev_epoch_canonical_roots(spec, fcr_store)
+        # fcr_store.prev_slot_head = fcr_store.current_slot_head will become True
         # after the update_fast_confirmation_variables call
-        # use store.current_slot_head as the future value of 'previous_slot_head' to check preconditions
-        will_be_prev_slot_head = store.current_slot_head
+        # use fcr_store.current_slot_head as the future value of 'previous_slot_head' to check preconditions
+        will_be_prev_slot_head = fcr_store.current_slot_head
 
         assert confirmed_epoch + 1 == current_epoch
         assert len(prev_epoch_canonical_roots) > 0
@@ -81,18 +81,19 @@ class PreviousEpochTestSpecification:
 
         if self.is_one_confirmed:
             assert spec.is_one_confirmed(
-                store, spec.get_current_balance_source(store), prev_epoch_canonical_roots[0]
+                store, spec.get_current_balance_source(fcr_store), prev_epoch_canonical_roots[0]
             )
         else:
             assert not spec.is_one_confirmed(
-                store, spec.get_current_balance_source(store), prev_epoch_canonical_roots[0]
+                store, spec.get_current_balance_source(fcr_store), prev_epoch_canonical_roots[0]
             )
 
-    def get_last_one_confirmed_block(self, spec, store):
+    def get_last_one_confirmed_block(self, spec, fcr_store):
+        store = fcr_store.store
         head = spec.get_head(store)
-        canonical_roots = spec.get_ancestor_roots(store, head, store.confirmed_root)
-        balance_source = spec.get_current_balance_source(store)
-        confirmed_root = store.confirmed_root
+        canonical_roots = spec.get_ancestor_roots(store, head, fcr_store.confirmed_root)
+        balance_source = spec.get_current_balance_source(fcr_store)
+        confirmed_root = fcr_store.confirmed_root
         for root in canonical_roots:
             if spec.is_one_confirmed(store, balance_source, root):
                 confirmed_root = root
@@ -101,21 +102,21 @@ class PreviousEpochTestSpecification:
 
         return confirmed_root
 
-    def get_expected_confirmed_root(self, spec, store):
+    def get_expected_confirmed_root(self, spec, fcr_store):
         if not self.is_one_confirmed:
-            return store.confirmed_root
+            return fcr_store.confirmed_root
 
         if not (self.no_conflicting_chkp or self.first_slot_call):
-            return store.confirmed_root
+            return fcr_store.confirmed_root
 
         if (self.prev_head_vs_fresh and self.prev_head_ancestor) and (
             self.first_slot_call or self.prev_head_uj_fresh or self.head_uj_fresh
         ):
-            return self.get_last_one_confirmed_block(spec, store)
+            return self.get_last_one_confirmed_block(spec, fcr_store)
         elif self.block_vs_fresh and (self.first_slot_call or self.head_uj_fresh):
-            return self.get_last_one_confirmed_block(spec, store)
+            return self.get_last_one_confirmed_block(spec, fcr_store)
         else:
-            return store.confirmed_root
+            return fcr_store.confirmed_root
 
     def is_vs_fresh(self):
         return self.block_vs_fresh and self.prev_head_vs_fresh
@@ -751,17 +752,19 @@ class PreviousEpochTestBuilder:
             debug_print("\n")
 
         # Check preconditions are correct
-        self.test_spec.verify_preconditions(fcr_test.spec, fcr_test.store)
+        self.test_spec.verify_preconditions(fcr_test.spec, fcr_test.fcr_store)
 
         return fcr_test
 
 
 def run_previous_epoch_test(fcr_test: FCRTest, test_spec: PreviousEpochTestSpecification):
     # Keep expected confirmed_root after execution of the test
-    expected_confirmed_root = test_spec.get_expected_confirmed_root(fcr_test.spec, fcr_test.store)
+    expected_confirmed_root = test_spec.get_expected_confirmed_root(
+        fcr_test.spec, fcr_test.fcr_store
+    )
     # Execute FCR and check that confirmed_root is as expected
     fcr_test.run_fast_confirmation()
-    assert fcr_test.store.confirmed_root == expected_confirmed_root
+    assert fcr_test.fcr_store.confirmed_root == expected_confirmed_root
 
     yield from fcr_test.get_test_artefacts()
 

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_reconfirmation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_reconfirmation.py
@@ -41,20 +41,20 @@ def test_reconfirmation_passes_with_empty_slots_prior_first_block(spec, state):
        from current_epoch - 2.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
     # Run until last slot of epoch 2
     fcr.run_slots_with_blocks_and_fast_confirmation(3 * S - 1, participation_rate=100)
 
-    confimed_at_last_slot_epoch_2 = store.confirmed_root
+    confimed_at_last_slot_epoch_2 = fcr_store.confirmed_root
 
     # Leave last slot empty
     fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
 
     # Check that reconfirmation passed
-    assert store.confirmed_root == confimed_at_last_slot_epoch_2
+    assert fcr_store.confirmed_root == confimed_at_last_slot_epoch_2
 
     # Epoch 3, Slot 1, empty slot
     fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
@@ -63,7 +63,7 @@ def test_reconfirmation_passes_with_empty_slots_prior_first_block(spec, state):
     fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     # Check that confirmed block was not advanced
-    assert store.confirmed_root == confimed_at_last_slot_epoch_2
+    assert fcr_store.confirmed_root == confimed_at_last_slot_epoch_2
 
     # Epoch 3, Slot 3
 
@@ -76,11 +76,11 @@ def test_reconfirmation_passes_with_empty_slots_prior_first_block(spec, state):
     fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=75)
 
     # Check the head is confirmed
-    assert store.confirmed_root == fcr.head()
+    assert fcr_store.confirmed_root == fcr.head()
 
     # But if there were no slashings, first block in Epoch 3 couldn't be confirmed at this stage
     epoch_3_first_block = spec.get_ancestor(store, fcr.head(), 3 * S + 1)
-    balance_source = spec.get_current_balance_source(store)
+    balance_source = spec.get_current_balance_source(fcr_store)
     support = spec.get_attestation_score(store, epoch_3_first_block, balance_source)
     safety_threshold = spec.compute_safety_threshold(store, epoch_3_first_block, balance_source)
 
@@ -96,12 +96,12 @@ def test_reconfirmation_passes_with_empty_slots_prior_first_block(spec, state):
     SlotSequence(end_slot=(4 * S - 1), attesting=Attesting(participation_rate=100)).execute(fcr)
 
     # Check the head was confirmed
-    assert store.confirmed_root == fcr.head()
+    assert fcr_store.confirmed_root == fcr.head()
 
     # Run to the start of Epoch 4 with no block
     fcr.attest_and_next_slot_with_fast_confirmation(participation_rate=100)
 
     # Check reconfirmation passed
-    assert store.confirmed_root == fcr.head()
+    assert fcr_store.confirmed_root == fcr.head()
 
     yield from fcr.get_test_artefacts()

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_restart_gu.py
@@ -32,7 +32,7 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     DEBUG: Verify restart-to-GU path is actually triggered.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch5_start = 5 * S
@@ -44,11 +44,11 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     assert fcr.current_slot() == epoch5_start - 1
     assert store.finalized_checkpoint.epoch >= spec.Epoch(2)
 
-    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
-        f"GU snapshot should be epoch 4, got {store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
+    assert fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
+        f"GU snapshot should be epoch 4, got {fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
     )
 
-    confirmed_before = store.confirmed_root
+    confirmed_before = fcr_store.confirmed_root
     finalized_root = store.finalized_checkpoint.root
     assert confirmed_before != finalized_root, (
         "Precondition: confirmed should be ahead of finalized"
@@ -66,7 +66,7 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
 
     # Before FCR: check reconfirmation status
     debug_print(
-        f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(store, confirmed_before)}"
+        f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(fcr_store, confirmed_before)}"
     )
     debug_print(f"confirmed_before slot: {store.blocks[confirmed_before].slot}")
     debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
@@ -77,28 +77,28 @@ def test_fcr_restarts_to_gu_when_all_conditions_met(spec, state):
     assert fcr.current_slot() == epoch5_start
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
-    gu = store.current_epoch_observed_justified_checkpoint
+    gu = fcr_store.current_epoch_observed_justified_checkpoint
     current_epoch = spec.get_current_store_epoch(store)
     finalized_root = store.finalized_checkpoint.root
 
     debug_print("\nAfter FCR:")
     debug_print(f"gu.epoch: {gu.epoch}, current_epoch: {current_epoch}")
-    debug_print(f"confirmed_root slot: {store.blocks[store.confirmed_root].slot}")
+    debug_print(f"confirmed_root slot: {store.blocks[fcr_store.confirmed_root].slot}")
     debug_print(f"gu.root slot: {store.blocks[gu.root].slot}")
     debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
-    debug_print(f"confirmed == gu.root: {store.confirmed_root == gu.root}")
-    debug_print(f"confirmed == finalized: {store.confirmed_root == finalized_root}")
-    debug_print(f"confirmed == confirmed_before: {store.confirmed_root == confirmed_before}")
+    debug_print(f"confirmed == gu.root: {fcr_store.confirmed_root == gu.root}")
+    debug_print(f"confirmed == finalized: {fcr_store.confirmed_root == finalized_root}")
+    debug_print(f"confirmed == confirmed_before: {fcr_store.confirmed_root == confirmed_before}")
 
     assert gu.epoch + 1 == current_epoch, (
         f"GU should be fresh after rotation: {gu.epoch} + 1 != {current_epoch}"
     )
 
-    assert store.confirmed_root != confirmed_before, (
+    assert fcr_store.confirmed_root != confirmed_before, (
         "Confirmed root should have changed (reconfirmation failed)"
     )
-    assert store.confirmed_root == gu.root, "Should restart to GU root"
-    assert store.confirmed_root != finalized_root, "Should NOT stay at finalized"
+    assert fcr_store.confirmed_root == gu.root, "Should restart to GU root"
+    assert fcr_store.confirmed_root != finalized_root, "Should NOT stay at finalized"
 
     yield from fcr.get_test_artefacts()
 
@@ -129,7 +129,7 @@ def test_fcr_restarts_to_gu_and_confirms_beyond_gu(spec, state):
           find_latest_confirmed_descendant
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch5_start = 5 * S
@@ -139,14 +139,14 @@ def test_fcr_restarts_to_gu_and_confirms_beyond_gu(spec, state):
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
         if fcr.current_slot() == epoch5_start - 2:
-            expected_confirmed_root_after_restart = store.confirmed_root
+            expected_confirmed_root_after_restart = fcr_store.confirmed_root
 
     assert fcr.current_slot() == epoch5_start - 1
     assert store.finalized_checkpoint.epoch >= spec.Epoch(2)
 
     # Verify GU snapshot is fresh before crossing
-    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
-        f"GU snapshot should be epoch 4, got {store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
+    assert fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
+        f"GU snapshot should be epoch 4, got {fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
     )
 
     # Last slot of epoch 4: build block, attest
@@ -166,7 +166,7 @@ def test_fcr_restarts_to_gu_and_confirms_beyond_gu(spec, state):
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
     # Verify postconditions after FCR (rotation has happened)
-    gu = store.current_epoch_observed_justified_checkpoint
+    gu = fcr_store.current_epoch_observed_justified_checkpoint
     finalized = store.finalized_checkpoint.root
     current_epoch = spec.get_current_store_epoch(store)
 
@@ -178,10 +178,10 @@ def test_fcr_restarts_to_gu_and_confirms_beyond_gu(spec, state):
     assert finalized_slot < gu_slot, f"slot(finalized)={finalized_slot} >= slot(GU)={gu_slot}"
 
     # Verify restart to GU and advance further (not finalized)
-    assert store.confirmed_root == expected_confirmed_root_after_restart, (
+    assert fcr_store.confirmed_root == expected_confirmed_root_after_restart, (
         "Should restart to GU and advance further"
     )
-    assert store.confirmed_root != finalized, "Should NOT stay at finalized"
+    assert fcr_store.confirmed_root != finalized, "Should NOT stay at finalized"
 
     yield from fcr.get_test_artefacts()
 
@@ -207,7 +207,7 @@ def test_fcr_no_restart_to_gu_mid_epoch(spec, state):
        - It either stays the same or advances monotonically
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -215,7 +215,7 @@ def test_fcr_no_restart_to_gu_mid_epoch(spec, state):
     while fcr.current_slot() < 3 * S:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-    confirmed_after_epoch2 = store.confirmed_root
+    confirmed_after_epoch2 = fcr_store.confirmed_root
     assert spec.get_block_epoch(store, confirmed_after_epoch2) == spec.Epoch(2)
 
     # Early epoch 3: Continue 100% for a few slots
@@ -224,17 +224,17 @@ def test_fcr_no_restart_to_gu_mid_epoch(spec, state):
     while fcr.current_slot() < epoch3_mid:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-    confirmed_mid_epoch3 = store.confirmed_root
+    confirmed_mid_epoch3 = fcr_store.confirmed_root
     assert spec.get_block_epoch(store, confirmed_mid_epoch3) == spec.Epoch(3)
 
     # Rest of epoch 3 + all of epoch 4: Drop to 20%
     # Track confirmed at each slot to verify no mid-epoch restart
-    prev_confirmed = store.confirmed_root
+    prev_confirmed = fcr_store.confirmed_root
 
     while fcr.current_slot() < 5 * S:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=20)
 
-        current_confirmed = store.confirmed_root
+        current_confirmed = fcr_store.confirmed_root
 
         # Confirmed should be monotonic (same or descendant), never jump backward
         assert current_confirmed == prev_confirmed or spec.is_ancestor(
@@ -270,7 +270,7 @@ def test_fcr_no_restart_to_gu_because_gu_too_old(spec, state):
        - Verify: confirmed == finalized, NOT GU
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -278,7 +278,7 @@ def test_fcr_no_restart_to_gu_because_gu_too_old(spec, state):
     while fcr.current_slot() < 3 * S:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-    confirmed_after_epoch2 = store.confirmed_root
+    confirmed_after_epoch2 = fcr_store.confirmed_root
     assert spec.get_block_epoch(store, confirmed_after_epoch2) == spec.Epoch(2)
 
     # Early epoch 3: Continue 100% for a few slots
@@ -287,7 +287,7 @@ def test_fcr_no_restart_to_gu_because_gu_too_old(spec, state):
     while fcr.current_slot() < epoch3_mid:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-    confirmed_mid_epoch3 = store.confirmed_root
+    confirmed_mid_epoch3 = fcr_store.confirmed_root
     assert spec.get_block_epoch(store, confirmed_mid_epoch3) == spec.Epoch(3)
 
     # Rest of epoch 3 + all of epoch 4: Drop to 20%
@@ -301,9 +301,9 @@ def test_fcr_no_restart_to_gu_because_gu_too_old(spec, state):
     assert spec.is_start_slot_at_epoch(fcr.current_slot())
 
     # Capture state before FCR
-    confirmed_before = store.confirmed_root
+    confirmed_before = fcr_store.confirmed_root
     confirmed_epoch_before = spec.get_block_epoch(store, confirmed_before)
-    gu = store.current_epoch_observed_justified_checkpoint
+    gu = fcr_store.current_epoch_observed_justified_checkpoint
     finalized = store.finalized_checkpoint
     current_epoch = spec.get_current_store_epoch(store)
 
@@ -321,7 +321,7 @@ def test_fcr_no_restart_to_gu_because_gu_too_old(spec, state):
     # Run FCR
     fcr.run_fast_confirmation()
 
-    confirmed_after = store.confirmed_root
+    confirmed_after = fcr_store.confirmed_root
 
     # Should have reset to finalized
     assert confirmed_after == finalized.root, (
@@ -349,7 +349,7 @@ def test_fcr_no_restart_when_gu_block_is_epoch_older(spec, state):
     DEBUG: Verify restart-to-GU path is actually triggered.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch4_start = 4 * S
@@ -369,11 +369,11 @@ def test_fcr_no_restart_when_gu_block_is_epoch_older(spec, state):
     assert fcr.current_slot() == epoch5_start - 1
     assert store.finalized_checkpoint.epoch >= spec.Epoch(2)
 
-    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
-        f"GU snapshot should be epoch 4, got {store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
+    assert fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(4), (
+        f"GU snapshot should be epoch 4, got {fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch}"
     )
 
-    confirmed_before = store.confirmed_root
+    confirmed_before = fcr_store.confirmed_root
     finalized_root = store.finalized_checkpoint.root
     assert confirmed_before != finalized_root, (
         "Precondition: confirmed should be ahead of finalized"
@@ -391,7 +391,7 @@ def test_fcr_no_restart_when_gu_block_is_epoch_older(spec, state):
 
     # Before FCR: check reconfirmation status
     debug_print(
-        f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(store, confirmed_before)}"
+        f"is_confirmed_chain_safe before FCR: {spec.is_confirmed_chain_safe(fcr_store, confirmed_before)}"
     )
     debug_print(f"confirmed_before slot: {store.blocks[confirmed_before].slot}")
     debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
@@ -402,18 +402,18 @@ def test_fcr_no_restart_when_gu_block_is_epoch_older(spec, state):
     assert fcr.current_slot() == epoch5_start
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
-    gu = store.current_epoch_observed_justified_checkpoint
+    gu = fcr_store.current_epoch_observed_justified_checkpoint
     current_epoch = spec.get_current_store_epoch(store)
     finalized_root = store.finalized_checkpoint.root
 
     debug_print("\nAfter FCR:")
     debug_print(f"gu.epoch: {gu.epoch}, current_epoch: {current_epoch}")
-    debug_print(f"confirmed_root slot: {store.blocks[store.confirmed_root].slot}")
+    debug_print(f"confirmed_root slot: {store.blocks[fcr_store.confirmed_root].slot}")
     debug_print(f"gu.root slot: {store.blocks[gu.root].slot}")
     debug_print(f"finalized slot: {store.blocks[finalized_root].slot}")
-    debug_print(f"confirmed == gu.root: {store.confirmed_root == gu.root}")
-    debug_print(f"confirmed == finalized: {store.confirmed_root == finalized_root}")
-    debug_print(f"confirmed == confirmed_before: {store.confirmed_root == confirmed_before}")
+    debug_print(f"confirmed == gu.root: {fcr_store.confirmed_root == gu.root}")
+    debug_print(f"confirmed == finalized: {fcr_store.confirmed_root == finalized_root}")
+    debug_print(f"confirmed == confirmed_before: {fcr_store.confirmed_root == confirmed_before}")
 
     assert gu.epoch + 1 == current_epoch, (
         f"GU should be fresh after rotation: {gu.epoch} + 1 != {current_epoch}"
@@ -423,6 +423,6 @@ def test_fcr_no_restart_when_gu_block_is_epoch_older(spec, state):
         f"GU block must be old after rotation: {spec.get_block_epoch(store, gu.root)} + 1 == {current_epoch}"
     )
 
-    assert store.confirmed_root == finalized_root, "MUST stay at finalized"
+    assert fcr_store.confirmed_root == finalized_root, "MUST stay at finalized"
 
     yield from fcr.get_test_artefacts()

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_revert_finality.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_revert_finality.py
@@ -40,7 +40,7 @@ def test_fcr_no_reset_when_confirmed_exactly_one_epoch_old(spec, state):
        because epoch(bcand=1) + 1 = 2 == current_epoch (not < current_epoch)
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch2_start = 2 * S
@@ -53,7 +53,7 @@ def test_fcr_no_reset_when_confirmed_exactly_one_epoch_old(spec, state):
     assert fcr.current_slot() == epoch2_start
 
     # Confirm we have confirmations in epoch 1
-    confirmed_at_epoch2_start = store.confirmed_root
+    confirmed_at_epoch2_start = fcr_store.confirmed_root
     assert confirmed_at_epoch2_start != store.finalized_checkpoint.root
     assert spec.get_block_epoch(store, confirmed_at_epoch2_start) == spec.Epoch(1)
 
@@ -64,7 +64,7 @@ def test_fcr_no_reset_when_confirmed_exactly_one_epoch_old(spec, state):
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=low_participation)
 
         current_epoch = spec.get_current_store_epoch(store)
-        confirmed_epoch = spec.get_block_epoch(store, store.confirmed_root)
+        confirmed_epoch = spec.get_block_epoch(store, fcr_store.confirmed_root)
 
         # Key invariant: throughout epoch 2, confirmed is in epoch 1
         # epoch(bcand=1) + 1 = 2 == current_epoch=2, so NOT "too old"
@@ -72,7 +72,7 @@ def test_fcr_no_reset_when_confirmed_exactly_one_epoch_old(spec, state):
         assert confirmed_epoch == spec.Epoch(1)
 
         # Should NOT have reset to finalized
-        assert store.confirmed_root != store.finalized_checkpoint.root, (
+        assert fcr_store.confirmed_root != store.finalized_checkpoint.root, (
             f"Unexpected reset at slot {fcr.current_slot()}: "
             f"confirmed_epoch={confirmed_epoch}, current_epoch={current_epoch}"
         )
@@ -101,7 +101,7 @@ def test_fcr_no_reset_at_epoch_boundary_with_full_participation(spec, state):
        - Reconfirmation passes (is_confirmed_chain_safe returns True)
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -117,7 +117,7 @@ def test_fcr_no_reset_at_epoch_boundary_with_full_participation(spec, state):
 
         # At epoch boundary
         if epoch > 0:  # Skip genesis epoch
-            current_confirmed = store.confirmed_root
+            current_confirmed = fcr_store.confirmed_root
             confirmed_epoch = spec.get_block_epoch(store, current_confirmed)
 
             confirmed_at_boundaries.append(
@@ -160,7 +160,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_too_old_lower_participation(spe
       - At epoch 3 start: reset confirmed_root to finalized.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch2_start = 2 * S
@@ -175,8 +175,8 @@ def test_fcr_reverts_to_finalized_when_confirmed_too_old_lower_participation(spe
     assert spec.is_start_slot_at_epoch(fcr.current_slot())
 
     # Confirm we are indeed in the regime "confirmed is in epoch 1".
-    assert store.confirmed_root != store.finalized_checkpoint.root
-    assert spec.get_block_epoch(store, store.confirmed_root) == spec.Epoch(1)
+    assert fcr_store.confirmed_root != store.finalized_checkpoint.root
+    assert spec.get_block_epoch(store, fcr_store.confirmed_root) == spec.Epoch(1)
 
     # 2) Epoch 2 with low participation: confirmed should not reset yet.
     low_participation = 60  # or 20/5; pick something clearly low for *confirmation* in your model
@@ -185,14 +185,14 @@ def test_fcr_reverts_to_finalized_when_confirmed_too_old_lower_participation(spe
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=low_participation)
 
         # Must not reset before epoch 3 start.
-        assert store.confirmed_root != store.finalized_checkpoint.root
+        assert fcr_store.confirmed_root != store.finalized_checkpoint.root
 
         # It should still be from epoch 1.
-        assert spec.get_block_epoch(store, store.confirmed_root) == spec.Epoch(1)
+        assert spec.get_block_epoch(store, fcr_store.confirmed_root) == spec.Epoch(1)
 
     # We are now at slot epoch3_start - 1, i.e., last slot before the boundary.
     assert fcr.current_slot() == epoch3_start - 1
-    pre_boundary_confirmed = store.confirmed_root
+    pre_boundary_confirmed = fcr_store.confirmed_root
     assert spec.get_block_epoch(store, pre_boundary_confirmed) == spec.Epoch(1)
 
     # 3) Cross into epoch 3 start: now it becomes "too old" and should reset.
@@ -208,7 +208,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_too_old_lower_participation(spe
     assert spec.get_block_epoch(store, pre_boundary_confirmed) + 1 < current_epoch
 
     # Must have reset to finalized at epoch 3 start.
-    assert store.confirmed_root == store.finalized_checkpoint.root
+    assert fcr_store.confirmed_root == store.finalized_checkpoint.root
 
     yield from fcr.get_test_artefacts()
 
@@ -238,7 +238,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_at_epoch_boundary
     7. FCR should reset confirmed_root to finalized
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch2_start = 2 * S
@@ -270,7 +270,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_at_epoch_boundary
 
     # Verify confirmed is on A-side
     head = fcr.head()
-    confirmed = store.confirmed_root
+    confirmed = fcr_store.confirmed_root
 
     assert spec.is_ancestor(store, head, confirmed), "Confirmed should be canonical"
     assert confirmed != store.finalized_checkpoint.root, "Confirmed should have advanced"
@@ -299,7 +299,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_at_epoch_boundary
     )
 
     # Verify reset to finalized
-    assert store.confirmed_root == store.finalized_checkpoint.root, (
+    assert fcr_store.confirmed_root == store.finalized_checkpoint.root, (
         "confirmed_root should reset to finalized when it becomes non-canonical"
     )
 
@@ -333,7 +333,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_mid_epoch(spec, s
     finalized_checkpoint.root rather than moving confirmations backward.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch2_start = 2 * S
@@ -369,10 +369,10 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_mid_epoch(spec, s
     )
 
     # By now we should have confirmed onto the A side
-    assert spec.is_ancestor(store, store.confirmed_root, a_root), "Confirmed did not reach A"
+    assert spec.is_ancestor(store, fcr_store.confirmed_root, a_root), "Confirmed did not reach A"
 
     # snapshot what confirmed_root is *before* we start pushing 100%-to-M
-    confirmed_before_flip = store.confirmed_root
+    confirmed_before_flip = fcr_store.confirmed_root
     assert confirmed_before_flip != store.finalized_checkpoint.root
     assert spec.is_ancestor(store, confirmed_before_flip, a_root)
 
@@ -381,7 +381,7 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_mid_epoch(spec, s
     fcr.attest_and_next_slot_with_fast_confirmation(block_root=m_root, participation_rate=100)
 
     # Confirmed still on A side
-    assert spec.is_ancestor(store, store.confirmed_root, a_root)
+    assert spec.is_ancestor(store, fcr_store.confirmed_root, a_root)
 
     # Next slot: build D on C; attest 100% to M again; advance + apply + FCR
     _d_root = fcr.add_and_apply_block(parent_root=c_root)
@@ -391,10 +391,10 @@ def test_fcr_reverts_to_finalized_when_confirmed_not_canonical_mid_epoch(spec, s
     # (FCR does not move confirmations backwards; it resets to finalized when confirmed becomes non-canonical.)
     head = fcr.head()
     assert spec.is_ancestor(store, head, m_root), "Head did not flip to M"
-    assert store.confirmed_root == store.finalized_checkpoint.root, (
+    assert fcr_store.confirmed_root == store.finalized_checkpoint.root, (
         "Expected reset to finalized mid-epoch"
     )
-    assert store.confirmed_root != confirmed_before_flip  # we actually reset
+    assert fcr_store.confirmed_root != confirmed_before_flip  # we actually reset
 
     yield from fcr.get_test_artefacts()
 
@@ -421,7 +421,7 @@ def test_fcr_reverts_when_reconfirmation_fails_at_epoch_start_due_to_late_equivo
     4. Reset fires, restart-to-GU rescues confirmed to GU root.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch3_start = 3 * S
@@ -432,14 +432,14 @@ def test_fcr_reverts_when_reconfirmation_fails_at_epoch_start_due_to_late_equivo
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     assert fcr.current_slot() == last_slot_epoch2
-    assert spec.get_block_epoch(store, store.confirmed_root) == spec.Epoch(2)
-    assert store.confirmed_root != store.finalized_checkpoint.root
+    assert spec.get_block_epoch(store, fcr_store.confirmed_root) == spec.Epoch(2)
+    assert fcr_store.confirmed_root != store.finalized_checkpoint.root
 
     # Last slot of epoch 2: build block, attest, run FCR (samples GU)
     block_root = fcr.add_and_apply_block(parent_root=fcr.head())
     fcr.attest(block_root=block_root, slot=fcr.current_slot(), participation_rate=100)
 
-    confirmed_before = store.confirmed_root
+    confirmed_before = fcr_store.confirmed_root
     current_epoch = spec.Epoch(3)
 
     # Pre-slashing: all reset disjuncts are false
@@ -453,14 +453,14 @@ def test_fcr_reverts_when_reconfirmation_fails_at_epoch_start_due_to_late_equivo
     assert spec.is_ancestor(store, fcr.head(), confirmed_before), "Confirmed not on head chain"
 
     # Confirmed above reconfirmation anchor
-    gu_prev = store.previous_epoch_observed_justified_checkpoint
+    gu_prev = fcr_store.previous_epoch_observed_justified_checkpoint
     assert spec.is_ancestor(store, confirmed_before, gu_prev.root), (
         "Confirmed not descendant of GU_prev"
     )
     assert confirmed_before != gu_prev.root, "No segment to reconfirm"
 
     # Reconfirmation passes
-    assert spec.is_confirmed_chain_safe(store, confirmed_before), (
+    assert spec.is_confirmed_chain_safe(fcr_store, confirmed_before), (
         "Reconfirmation should pass before slashing"
     )
 
@@ -476,7 +476,7 @@ def test_fcr_reverts_when_reconfirmation_fails_at_epoch_start_due_to_late_equivo
     assert spec.is_ancestor(store, confirmed_before, gu_prev.root), "Ancestry broke"
 
     # Reconfirmation fails
-    assert not spec.is_confirmed_chain_safe(store, confirmed_before), (
+    assert not spec.is_confirmed_chain_safe(fcr_store, confirmed_before), (
         "Reconfirmation should fail after 75% slashing"
     )
 
@@ -486,12 +486,12 @@ def test_fcr_reverts_when_reconfirmation_fails_at_epoch_start_due_to_late_equivo
     fcr.run_fast_confirmation()
 
     # Outcome: reset fired, restart-to-GU worked
-    gu_at_epoch3 = store.current_epoch_observed_justified_checkpoint
-    assert store.confirmed_root != confirmed_before, (
+    gu_at_epoch3 = fcr_store.current_epoch_observed_justified_checkpoint
+    assert fcr_store.confirmed_root != confirmed_before, (
         "Confirmed should have moved — reconfirmation failure not triggered"
     )
-    assert store.confirmed_root == gu_at_epoch3.root, (
-        f"Expected restart to GU root, got {store.confirmed_root}"
+    assert fcr_store.confirmed_root == gu_at_epoch3.root, (
+        f"Expected restart to GU root, got {fcr_store.confirmed_root}"
     )
 
     yield from fcr.get_test_artefacts()
@@ -532,7 +532,7 @@ def test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch(spec, s
     Result: confirmed_root = finalized_checkpoint.root (NOT GU)
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch2_start = 2 * S
@@ -543,7 +543,7 @@ def test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch(spec, s
     while fcr.current_slot() < epoch2_start:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
-        if store.confirmed_root != store.finalized_checkpoint.root:
+        if fcr_store.confirmed_root != store.finalized_checkpoint.root:
             saw_nonfinal_confirmed = True
 
     assert fcr.current_slot() == epoch2_start
@@ -560,7 +560,7 @@ def test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch(spec, s
 
         # Must not reset early (only care that reset happens at epoch 3 start).
         if fcr.current_slot() < epoch3_start:
-            assert store.confirmed_root != store.finalized_checkpoint.root, (
+            assert fcr_store.confirmed_root != store.finalized_checkpoint.root, (
                 "confirmed_root reset before epoch 3 start (unexpected for this scenario)"
             )
 
@@ -573,7 +573,7 @@ def test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch(spec, s
 
     # current_epoch_observed_justified_checkpoint is set from unrealized_justified_checkpoint
     # at the start of the last slot of the previous epoch.
-    gu = store.current_epoch_observed_justified_checkpoint
+    gu = fcr_store.current_epoch_observed_justified_checkpoint
 
     # Finalized strictly older than GU at the block/slot level
     finalized_slot = store.blocks[store.finalized_checkpoint.root].slot
@@ -586,7 +586,7 @@ def test_reset_to_finality_but_no_restart_to_gu_because_gu_too_old_epoch(spec, s
     )
 
     # Reset-to-finalized must happen at epoch 3 start due to confirmed being "too old".
-    assert store.confirmed_root == store.finalized_checkpoint.root
+    assert fcr_store.confirmed_root == store.finalized_checkpoint.root
 
     yield from fcr.get_test_artefacts()
 
@@ -628,7 +628,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     NOT due to bcand being too old or non-canonical.
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
     epoch2_start = 2 * S
@@ -720,7 +720,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
 
     # Check GU snapshot = (C, 2) — use the snapshot field, not current_observed
     # (rotation hasn't happened yet, it happens at epoch 4 start inside FCR)
-    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
+    gu_snapshot = fcr_store.previous_epoch_greatest_unrealized_checkpoint
     assert gu_snapshot.root == c_red, "GU snapshot should point to c_red"
     assert gu_snapshot.epoch == spec.Epoch(2)
 
@@ -737,8 +737,8 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     assert spec.is_ancestor(store, uj_of_b_prime.root, c_double_prime)
 
     # GU snapshot should STILL be (C, 2) — releasing b' doesn't change it
-    assert store.previous_epoch_greatest_unrealized_checkpoint.root == c_red
-    assert store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(2)
+    assert fcr_store.previous_epoch_greatest_unrealized_checkpoint.root == c_red
+    assert fcr_store.previous_epoch_greatest_unrealized_checkpoint.epoch == spec.Epoch(2)
 
     fcr.attest(block_root=b_prime, slot=fcr.current_slot(), participation_rate=100)
 
@@ -749,7 +749,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot()))
 
     # Verify preconditions BEFORE FCR
-    confirmed_before_fcr = store.confirmed_root
+    confirmed_before_fcr = fcr_store.confirmed_root
     current_epoch = spec.get_current_store_epoch(store)
     confirmed_epoch = spec.get_block_epoch(store, confirmed_before_fcr)
 
@@ -766,7 +766,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     fcr.run_fast_confirmation()
 
     # Verify GU after rotation
-    gu = store.current_epoch_observed_justified_checkpoint
+    gu = fcr_store.current_epoch_observed_justified_checkpoint
     assert gu.root == c_red, "GU should be c_red after rotation"
     assert gu.epoch == spec.Epoch(2)
 
@@ -776,7 +776,7 @@ def test_fcr_resets_when_bcand_not_descendant_of_gu_via_first_received_uj(spec, 
     )
 
     # Verify reset to finalized
-    confirmed_after_fcr = store.confirmed_root
+    confirmed_after_fcr = fcr_store.confirmed_root
     finalized = store.finalized_checkpoint.root
     assert confirmed_after_fcr == finalized, (
         "confirmed_root should reset to finalized due to bcand ⊁ GU"

--- a/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_variables.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fast_confirmation/test_variables.py
@@ -34,9 +34,9 @@ def test_fcr_invariants_monotone_and_canonical(spec, state):
        the head chain, ensuring confirmed blocks are always canonical
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
-    prev_confirmed_slot = store.blocks[store.confirmed_root].slot
+    prev_confirmed_slot = store.blocks[fcr_store.confirmed_root].slot
 
     # Run through an entire epoch + 1 to cross epoch boundary
     # This tests reconfirmation and restart logic
@@ -44,7 +44,7 @@ def test_fcr_invariants_monotone_and_canonical(spec, state):
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
         head = fcr.head()
-        confirmed = store.confirmed_root
+        confirmed = fcr_store.confirmed_root
 
         # Invariant 1: confirmed must be on canonical chain
         assert spec.is_ancestor(store, head, confirmed)
@@ -84,7 +84,7 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
     4. During other mid-epoch slots, nothing changes
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -92,10 +92,10 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
     anchor_root = store.finalized_checkpoint.root
     anchor_epoch = store.finalized_checkpoint.epoch
 
-    assert store.previous_epoch_observed_justified_checkpoint.root == anchor_root
-    assert store.previous_epoch_observed_justified_checkpoint.epoch == anchor_epoch
-    assert store.current_epoch_observed_justified_checkpoint.root == anchor_root
-    assert store.current_epoch_observed_justified_checkpoint.epoch == anchor_epoch
+    assert fcr_store.previous_epoch_observed_justified_checkpoint.root == anchor_root
+    assert fcr_store.previous_epoch_observed_justified_checkpoint.epoch == anchor_epoch
+    assert fcr_store.current_epoch_observed_justified_checkpoint.root == anchor_root
+    assert fcr_store.current_epoch_observed_justified_checkpoint.epoch == anchor_epoch
 
     # Run through epochs 0 and 1 to get to epoch 2
     while fcr.current_slot() < 2 * S:
@@ -105,8 +105,8 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
 
     # 2. Check mid-epoch slots don't update observed checkpoints
     # Record values at start of epoch 2 (rotation just happened here)
-    prev_at_epoch2_start = store.previous_epoch_observed_justified_checkpoint
-    curr_at_epoch2_start = store.current_epoch_observed_justified_checkpoint
+    prev_at_epoch2_start = fcr_store.previous_epoch_observed_justified_checkpoint
+    curr_at_epoch2_start = fcr_store.current_epoch_observed_justified_checkpoint
 
     # Run through mid-epoch slots of epoch 2 (not last slot, not first slot of next epoch)
     last_slot_of_epoch2 = 3 * S - 1
@@ -122,10 +122,10 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
         )
 
         # Observed checkpoints should NOT have changed
-        assert store.previous_epoch_observed_justified_checkpoint == prev_at_epoch2_start, (
+        assert fcr_store.previous_epoch_observed_justified_checkpoint == prev_at_epoch2_start, (
             f"previous_epoch_observed changed at mid-epoch slot {fcr.current_slot()}"
         )
-        assert store.current_epoch_observed_justified_checkpoint == curr_at_epoch2_start, (
+        assert fcr_store.current_epoch_observed_justified_checkpoint == curr_at_epoch2_start, (
             f"current_epoch_observed changed at mid-epoch slot {fcr.current_slot()}"
         )
 
@@ -133,8 +133,8 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
     assert fcr.current_slot() == last_slot_of_epoch2 - 1
 
     # Record state before the last slot
-    prev_before_last_slot = store.previous_epoch_observed_justified_checkpoint
-    curr_before_last_slot = store.current_epoch_observed_justified_checkpoint
+    prev_before_last_slot = fcr_store.previous_epoch_observed_justified_checkpoint
+    curr_before_last_slot = fcr_store.current_epoch_observed_justified_checkpoint
 
     # Advance to last slot of epoch 2
     fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
@@ -146,21 +146,22 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
 
     # After last slot: GU snapshot is taken into previous_epoch_greatest_unrealized_checkpoint
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
+        fcr_store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
     ), "previous_epoch_greatest_unrealized_checkpoint should snapshot unrealized at last slot"
 
     # But observed checkpoints should NOT have rotated yet
-    assert store.previous_epoch_observed_justified_checkpoint == prev_before_last_slot, (
+    assert fcr_store.previous_epoch_observed_justified_checkpoint == prev_before_last_slot, (
         "previous_epoch_observed should NOT change at last slot of epoch"
     )
-    assert store.current_epoch_observed_justified_checkpoint == curr_before_last_slot, (
+    assert fcr_store.current_epoch_observed_justified_checkpoint == curr_before_last_slot, (
         "current_epoch_observed should NOT change at last slot of epoch"
     )
 
     # 4. Check first slot of epoch 3: NOW the rotation happens
     # Record the snapshot and current_observed before crossing the boundary
-    gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
-    curr_before_epoch_start = store.current_epoch_observed_justified_checkpoint
+    gu_snapshot = fcr_store.previous_epoch_greatest_unrealized_checkpoint
+    curr_before_epoch_start = fcr_store.current_epoch_observed_justified_checkpoint
 
     # Advance to first slot of epoch 3
     fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
@@ -173,11 +174,11 @@ def test_observed_justified_checkpoints_update_timing(spec, state):
 
     # After epoch start: observed checkpoints rotate
     # previous_observed := old current_observed
-    assert store.previous_epoch_observed_justified_checkpoint == curr_before_epoch_start, (
+    assert fcr_store.previous_epoch_observed_justified_checkpoint == curr_before_epoch_start, (
         "previous_epoch_observed should now equal what current_epoch_observed was before rotation"
     )
     # current_observed := the GU snapshot taken at the last slot of the previous epoch
-    assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+    assert fcr_store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
         "current_epoch_observed should now equal the GU snapshot from last slot of previous epoch"
     )
 
@@ -205,12 +206,12 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
        current_observed at epoch e start
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
-    prev_current_observed_epoch = store.current_epoch_observed_justified_checkpoint.epoch
-    prev_previous_observed_epoch = store.previous_epoch_observed_justified_checkpoint.epoch
+    prev_current_observed_epoch = fcr_store.current_epoch_observed_justified_checkpoint.epoch
+    prev_previous_observed_epoch = fcr_store.previous_epoch_observed_justified_checkpoint.epoch
 
     # Records sampled at the first slot of each epoch (where rotation happens)
     observed_at_epoch_start = []
@@ -224,8 +225,8 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
             fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
             # Observed checkpoint epochs never decrease under full participation
-            current_observed_epoch = store.current_epoch_observed_justified_checkpoint.epoch
-            previous_observed_epoch = store.previous_epoch_observed_justified_checkpoint.epoch
+            current_observed_epoch = fcr_store.current_epoch_observed_justified_checkpoint.epoch
+            previous_observed_epoch = fcr_store.previous_epoch_observed_justified_checkpoint.epoch
 
             assert current_observed_epoch >= prev_current_observed_epoch, (
                 f"current_epoch_observed went backwards: "
@@ -244,13 +245,13 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
         assert spec.is_start_slot_at_epoch(spec.Slot(fcr.current_slot() + 1))
 
         assert (
-            store.previous_epoch_greatest_unrealized_checkpoint
+            fcr_store.previous_epoch_greatest_unrealized_checkpoint
             == store.unrealized_justified_checkpoint
         ), f"At epoch {epoch} last slot: GU snapshot != unrealized"
 
         # Record the GU snapshot and current_observed before rotation
-        gu_snapshot = store.previous_epoch_greatest_unrealized_checkpoint
-        curr_observed_before_rotation = store.current_epoch_observed_justified_checkpoint
+        gu_snapshot = fcr_store.previous_epoch_greatest_unrealized_checkpoint
+        curr_observed_before_rotation = fcr_store.current_epoch_observed_justified_checkpoint
 
         # Advance to first slot of next epoch — rotation happens here
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
@@ -260,15 +261,15 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
 
         # Verify rotation happened correctly
         assert (
-            store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation
+            fcr_store.previous_epoch_observed_justified_checkpoint == curr_observed_before_rotation
         ), f"At epoch {epoch + 1} start: previous_observed != old current_observed"
-        assert store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
+        assert fcr_store.current_epoch_observed_justified_checkpoint == gu_snapshot, (
             f"At epoch {epoch + 1} start: current_observed != GU snapshot from last slot"
         )
 
         # Monotonicity check continues through epoch start
-        current_observed_epoch = store.current_epoch_observed_justified_checkpoint.epoch
-        previous_observed_epoch = store.previous_epoch_observed_justified_checkpoint.epoch
+        current_observed_epoch = fcr_store.current_epoch_observed_justified_checkpoint.epoch
+        previous_observed_epoch = fcr_store.previous_epoch_observed_justified_checkpoint.epoch
 
         assert current_observed_epoch >= prev_current_observed_epoch, (
             f"current_epoch_observed went backwards at epoch start: "
@@ -286,8 +287,8 @@ def test_observed_justified_checkpoints_properties_across_epochs(spec, state):
         observed_at_epoch_start.append(
             {
                 "epoch": epoch + 1,
-                "previous_observed": store.previous_epoch_observed_justified_checkpoint,
-                "current_observed": store.current_epoch_observed_justified_checkpoint,
+                "previous_observed": fcr_store.previous_epoch_observed_justified_checkpoint,
+                "current_observed": fcr_store.current_epoch_observed_justified_checkpoint,
                 "previous_observed_epoch": int(previous_observed_epoch),
                 "current_observed_epoch": int(current_observed_epoch),
             }
@@ -326,10 +327,10 @@ def test_observed_justified_stalls_under_low_participation(spec, state):
     - previous_epoch_observed stays at genesis
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
-    genesis_epoch = store.current_epoch_observed_justified_checkpoint.epoch
+    genesis_epoch = fcr_store.current_epoch_observed_justified_checkpoint.epoch
 
     # Run 3 epochs with very low participation (20%)
     for _ in range(3 * S):
@@ -337,11 +338,11 @@ def test_observed_justified_stalls_under_low_participation(spec, state):
 
     # With 20% participation, justification should not occur
     # Therefore observed checkpoints should still be at genesis
-    assert store.current_epoch_observed_justified_checkpoint.epoch == genesis_epoch, (
-        f"current_epoch_observed advanced despite low participation: {store.current_epoch_observed_justified_checkpoint.epoch}"
+    assert fcr_store.current_epoch_observed_justified_checkpoint.epoch == genesis_epoch, (
+        f"current_epoch_observed advanced despite low participation: {fcr_store.current_epoch_observed_justified_checkpoint.epoch}"
     )
-    assert store.previous_epoch_observed_justified_checkpoint.epoch == genesis_epoch, (
-        f"previous_epoch_observed advanced despite low participation: {store.previous_epoch_observed_justified_checkpoint.epoch}"
+    assert fcr_store.previous_epoch_observed_justified_checkpoint.epoch == genesis_epoch, (
+        f"previous_epoch_observed advanced despite low participation: {fcr_store.previous_epoch_observed_justified_checkpoint.epoch}"
     )
 
     yield from fcr.get_test_artefacts()
@@ -365,11 +366,11 @@ def test_slot_head_variables_updated_every_slot(spec, state):
         current_slot_head = get_head(store)
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
-    curr_slot_head_before = store.current_slot_head
+    curr_slot_head_before = fcr_store.current_slot_head
 
     # Run several slots and verify the cascade happens each slot
     for i in range(S + 2):  # Run past one epoch boundary
@@ -378,8 +379,8 @@ def test_slot_head_variables_updated_every_slot(spec, state):
         # After each slot, previous should equal what current was before
         # and current should equal the new head
         expected_previous = curr_slot_head_before
-        actual_previous = store.previous_slot_head
-        actual_current = store.current_slot_head
+        actual_previous = fcr_store.previous_slot_head
+        actual_current = fcr_store.current_slot_head
         actual_head = fcr.head()
 
         assert actual_previous == expected_previous, (
@@ -414,13 +415,13 @@ def test_gu_snapshot_initialization_and_stability(spec, state):
        unrealized_justified_checkpoint changes due to epoch processing
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
     # 1. Check initialization — should equal anchor checkpoint at genesis
     anchor_checkpoint = store.finalized_checkpoint
-    assert store.previous_epoch_greatest_unrealized_checkpoint == anchor_checkpoint, (
+    assert fcr_store.previous_epoch_greatest_unrealized_checkpoint == anchor_checkpoint, (
         "previous_epoch_greatest_unrealized_checkpoint should equal anchor at genesis"
     )
 
@@ -429,36 +430,36 @@ def test_gu_snapshot_initialization_and_stability(spec, state):
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     # Now at first slot of epoch 1 — run mid-epoch and verify snapshot doesn't change
-    gu_snapshot_after_epoch0 = store.previous_epoch_greatest_unrealized_checkpoint
+    gu_snapshot_after_epoch0 = fcr_store.previous_epoch_greatest_unrealized_checkpoint
 
     last_slot_of_epoch1 = 2 * S - 1
     while fcr.current_slot() < last_slot_of_epoch1 - 1:
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
         # 2. Snapshot should NOT change during mid-epoch slots
-        assert store.previous_epoch_greatest_unrealized_checkpoint == gu_snapshot_after_epoch0, (
-            f"GU snapshot changed at mid-epoch slot {fcr.current_slot()}"
-        )
+        assert (
+            fcr_store.previous_epoch_greatest_unrealized_checkpoint == gu_snapshot_after_epoch0
+        ), f"GU snapshot changed at mid-epoch slot {fcr.current_slot()}"
 
     # Advance to last slot of epoch 1 — new snapshot is taken
     fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
     assert fcr.current_slot() == last_slot_of_epoch1
 
     # 3. Snapshot should now reflect the current unrealized_justified_checkpoint
-    snapshot_at_last_slot = store.previous_epoch_greatest_unrealized_checkpoint
+    snapshot_at_last_slot = fcr_store.previous_epoch_greatest_unrealized_checkpoint
     assert snapshot_at_last_slot == store.unrealized_justified_checkpoint, (
         "GU snapshot should equal unrealized at last slot of epoch"
     )
 
     # Record snapshot before crossing into next epoch
-    snapshot_before_epoch_start = store.previous_epoch_greatest_unrealized_checkpoint
+    snapshot_before_epoch_start = fcr_store.previous_epoch_greatest_unrealized_checkpoint
 
     # Advance to first slot of epoch 2 — epoch processing may advance unrealized
     fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
     assert fcr.current_slot() == 2 * S
 
     # The rotation should use the snapshot value, NOT the (possibly updated) unrealized
-    assert store.current_epoch_observed_justified_checkpoint == snapshot_before_epoch_start, (
+    assert fcr_store.current_epoch_observed_justified_checkpoint == snapshot_before_epoch_start, (
         "Rotation should use the GU snapshot, not the live unrealized_justified_checkpoint"
     )
 
@@ -487,7 +488,7 @@ def test_observed_justified_stable_during_last_slot(spec, state):
     last slot of the epoch as they did at the first slot
     """
     fcr = FCRTest(spec, seed=1)
-    store = fcr.initialize(state)
+    store, fcr_store = fcr.initialize(state)
 
     S = spec.SLOTS_PER_EPOCH
 
@@ -496,8 +497,8 @@ def test_observed_justified_stable_during_last_slot(spec, state):
         fcr.next_slot_with_block_and_fast_confirmation(participation_rate=100)
 
     # Now at first slot of epoch 2 — record observed checkpoints
-    curr_observed_at_epoch_start = store.current_epoch_observed_justified_checkpoint
-    prev_observed_at_epoch_start = store.previous_epoch_observed_justified_checkpoint
+    curr_observed_at_epoch_start = fcr_store.current_epoch_observed_justified_checkpoint
+    prev_observed_at_epoch_start = fcr_store.previous_epoch_observed_justified_checkpoint
 
     # Run through the entire epoch, all the way to the last slot
     last_slot_of_epoch2 = 3 * S - 1
@@ -508,18 +509,19 @@ def test_observed_justified_stable_during_last_slot(spec, state):
 
     # Observed checkpoints must be the same as at epoch start
     # This is what the old code got wrong — it would have rotated them here
-    assert store.current_epoch_observed_justified_checkpoint == curr_observed_at_epoch_start, (
+    assert fcr_store.current_epoch_observed_justified_checkpoint == curr_observed_at_epoch_start, (
         "current_epoch_observed must remain stable throughout the entire epoch "
         "(including the last slot)"
     )
-    assert store.previous_epoch_observed_justified_checkpoint == prev_observed_at_epoch_start, (
+    assert fcr_store.previous_epoch_observed_justified_checkpoint == prev_observed_at_epoch_start, (
         "previous_epoch_observed must remain stable throughout the entire epoch "
         "(including the last slot)"
     )
 
     # But the GU snapshot should have been taken
     assert (
-        store.previous_epoch_greatest_unrealized_checkpoint == store.unrealized_justified_checkpoint
+        fcr_store.previous_epoch_greatest_unrealized_checkpoint
+        == store.unrealized_justified_checkpoint
     ), "GU snapshot should be taken at last slot even though observed checkpoints don't rotate"
 
     yield from fcr.get_test_artefacts()


### PR DESCRIPTION
### Description
Introduces `FastConfirmationStore` and moves all FCR variables to that store.
`FastConfirmationStore` includes an instance of `Store` to avoid passing two different types of store to FCR functions.

This proposal doesn’t introduce any semantics changes to the algorithm itself.

### Motivation
Makes the FCR spec more self-contained and less impactful on other parts of the specification.

FCR algorithm heavily uses the fork choice `Store` and the main downside of this change is that the readability of the FCR spec is slightly reduced by making the spec relying on two different stores. The proposal attempts to keep the footprint of the change as minimal as possible.